### PR TITLE
kernel_netlink.c: don't include <linux/if_bridge.h>

### DIFF
--- a/kernel_netlink.c
+++ b/kernel_netlink.c
@@ -39,9 +39,13 @@ THE SOFTWARE.
 #include <sys/socket.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
-#include <linux/if_bridge.h>
 #include <linux/fib_rules.h>
 #include <net/if_arp.h>
+
+/* From <linux/if_bridge.h> */
+#ifndef BRCTL_GET_BRIDGES
+#define BRCTL_GET_BRIDGES 1
+#endif
 
 #if(__GLIBC__ < 2) || (__GLIBC__ == 2 && __GLIBC_MINOR__ <= 5)
 #define RTA_TABLE 15


### PR DESCRIPTION
Including <linux/if_bridge.h> causes the inclusion of <linux/in6.h>,
which defines 'struct in6_addr', also defined in <netinet/in.h>, causing
a build failure with the musl C library:

In file included from /home/thomas/projets/buildroot/output/host/usr/x86_64-buildroot-linux-musl/sysroot/usr/include/linux/if_bridge.h:18:0,
                 from kernel_netlink.c:42,
                 from kernel.c:31:
/home/thomas/projets/buildroot/output/host/usr/x86_64-buildroot-linux-musl/sysroot/usr/include/linux/in6.h:32:8: error: redefinition of ‘struct in6_addr’
 struct in6_addr {
        ^
In file included from kernel_netlink.c:33:0,
                 from kernel.c:31:
/home/thomas/projets/buildroot/output/host/usr/x86_64-buildroot-linux-musl/sysroot/usr/include/netinet/in.h:23:8: note: originally defined here
 struct in6_addr {
        ^
In file included from /home/thomas/projets/buildroot/output/host/usr/x86_64-buildroot-linux-musl/sysroot/usr/include/linux/if_bridge.h:18:0,
                 from kernel_netlink.c:42,
                 from kernel.c:31:
/home/thomas/projets/buildroot/output/host/usr/x86_64-buildroot-linux-musl/sysroot/usr/include/linux/in6.h:49:8: error: redefinition of ‘struct sockaddr_in6’
 struct sockaddr_in6 {
        ^
In file included from kernel_netlink.c:33:0,
                 from kernel.c:31:
/home/thomas/projets/buildroot/output/host/usr/x86_64-buildroot-linux-musl/sysroot/usr/include/netinet/in.h:34:8: note: originally defined here
 struct sockaddr_in6 {
        ^
In file included from /home/thomas/projets/buildroot/output/host/usr/x86_64-buildroot-linux-musl/sysroot/usr/include/linux/if_bridge.h:18:0,
                 from kernel_netlink.c:42,
                 from kernel.c:31:
/home/thomas/projets/buildroot/output/host/usr/x86_64-buildroot-linux-musl/sysroot/usr/include/linux/in6.h:59:8: error: redefinition of ‘struct ipv6_mreq’
 struct ipv6_mreq {
        ^
In file included from kernel_netlink.c:33:0,
                 from kernel.c:31:
/home/thomas/projets/buildroot/output/host/usr/x86_64-buildroot-linux-musl/sysroot/usr/include/netinet/in.h:42:8: note: originally defined here
 struct ipv6_mreq {
        ^

In order to address this, this patch removes the <linux/if_bridge.h>
inclusion, and instead defines BRCTL_GET_BRIDGES to the appropriate
value if it's not provided by the C library.

Signed-off-by: Thomas Petazzoni thomas.petazzoni@free-electrons.com
