### PR TITLE
Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ version.h
 cscope.out
 gmon.out
 core
+babeld-whole.*

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ version.h
 cscope.out
 gmon.out
 core
-babeld-whole.*
+babeld-whole*
+tags
+TAGS

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 babeld
 babeld.html
 version.h
+cscope.out
+gmon.out
+core

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@ OBJS = babeld.o net.o kernel.o util.o interface.o source.o neighbour.o \
        route.o xroute.o message.o resend.o configuration.o local.o \
        disambiguation.o rule.o
 
+INCLUDES = babeld.h net.h kernel.c util.h interface.h source.h neighbour.h \
+       route.h xroute.h message.h resend.h configuration.h local.h \
+       disambiguation.h rule.h
+
 babeld: $(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o babeld $(OBJS) $(LDLIBS)
 
@@ -36,9 +40,15 @@ version.h:
 
 babeld.html: babeld.man
 
-.PHONY: all install install.minimal uninstall clean
+.PHONY: all install install.minimal uninstall clean reallyclean
 
 all: babeld babeld.man
+
+TAGS: $(SRCS) $(INCLUDES)
+	etags $(SRCS) $(INCLUDES)
+
+tags: $(SRCS) $(INCLUDES)
+	ctags $(SRCS) $(INCLUDES)
 
 install.minimal: babeld
 	-rm -f $(TARGET)$(PREFIX)/bin/babeld
@@ -54,4 +64,7 @@ uninstall:
 	-rm -f $(TARGET)$(MANDIR)/man8/babeld.8
 
 clean:
-	-rm -f babeld babeld.html version.h *.o *~ core TAGS gmon.out
+	-rm -f babeld babeld.html version.h *.o *~ core
+
+reallyclean: clean
+	-rm -f TAGS tags gmon.out

--- a/Makefile
+++ b/Makefile
@@ -67,4 +67,4 @@ clean:
 	-rm -f babeld babeld.html version.h *.o *~ core
 
 reallyclean: clean
-	-rm -f TAGS tags gmon.out
+	-rm -f TAGS tags gmon.out cscope.out

--- a/Makefile
+++ b/Makefile
@@ -19,17 +19,49 @@ OBJS = babeld.o net.o kernel.o util.o interface.o source.o neighbour.o \
 
 INCLUDES = babeld.h net.h kernel.c util.h interface.h source.h neighbour.h \
        route.h xroute.h message.h resend.h configuration.h local.h \
-       disambiguation.h rule.h
+       disambiguation.h rule.h version.h
 
 babeld: $(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o babeld $(OBJS) $(LDLIBS)
 
-babeld.o: babeld.c version.h
+babeld.o: babeld.c $(INCLUDES)
 
-local.o: local.c version.h
+local.o: local.c local.h version.h babeld.h interface.h source.h neighbour.h \
+	 kernel.h xroute.h route.h util.h configuration.h
 
-kernel.o: kernel_netlink.c kernel_socket.c
+kernel.o: kernel_netlink.c kernel_socket.c kernel.h babeld.h
 
+configuration.o: configuration.c babeld.h util.h route.h kernel.h \
+		 configuration.h rule.h
+
+disambiguation.o: disambiguation.c babeld.h util.h route.h kernel.h \
+		  disambiguation.h interface.h rule.h
+
+interface.o: interface.c babeld.h util.h route.h kernel.h local.h \
+	     interface.h neighbour.h message.h configuration.h xroute.h
+
+message.o: message.c babeld.h util.h net.h interface.h source.h neighbour.h \
+	   route.h kernel.h xroute.h resend.h configuration.h
+
+neighbour.o: neighbour.c babeld.h util.h interface.h source.h route.h \
+	     neighbour.h message.h resend.h local.h
+
+net.o: net.c net.h babeld.h util.h
+
+resend.o: resend.c babeld.h util.h neighbour.h message.h interface.h \
+	  resend.h configuration.h
+
+route.o: route.c babeld.h util.h kernel.h interface.h source.h neighbour.h \
+	 route.h xroute.h message.h configuration.h local.h disambiguation.h
+
+rule.o: rule.c babeld.h util.h kernel.h configuration.h rule.h
+
+source.o: source.c babeld.h util.h interface.h route.h source.h
+
+util.o: util.c babeld.h util.h
+
+xroute.o: xroute.c babeld.h kernel.h neighbour.h message.h route.h util.h \
+	  xroute.h configuration.h interface.h local.h
 version.h:
 	./generate-version.sh > version.h
 

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,19 @@ xroute.o: xroute.c babeld.h kernel.h neighbour.h message.h route.h util.h \
 version.h:
 	./generate-version.sh > version.h
 
+# Whole program compilation with maximum optimization
+
+babeld-whole.c: $(SRCS) $(INCLUDES)
+	cat $(SRCS) > babeld-whole.c
+
+babeld-whole.s: babeld-whole.c
+	$(CC) $(CFLAGS) -O3 $(LDFLAGS) -fwhole-program -fverbose-asm \
+	                 babeld-whole.c -S -o babeld-whole.s
+
+babeld-whole: babeld-whole.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -O3 -fwhole-program babeld-whole.c \
+	                           -o babeld-whole $(LDLIBS)
+
 .SUFFIXES: .man .html
 
 .man.html:
@@ -96,7 +109,7 @@ uninstall:
 	-rm -f $(TARGET)$(MANDIR)/man8/babeld.8
 
 clean:
-	-rm -f babeld babeld.html version.h *.o *~ core
+	-rm -f babeld babeld.html version.h *.o *~ core babeld-whole.*
 
 reallyclean: clean
 	-rm -f TAGS tags gmon.out cscope.out

--- a/babeld.h
+++ b/babeld.h
@@ -1,3 +1,5 @@
+#ifndef _BABEL_BABELD
+#define _BABEL_BABELD
 /*
 Copyright (c) 2007, 2008 by Juliusz Chroboczek
 
@@ -110,3 +112,5 @@ void schedule_neighbours_check(int msecs, int override);
 void schedule_interfaces_check(int msecs, int override);
 int resize_receive_buffer(int size);
 int reopen_logfile(void);
+
+#endif

--- a/configuration.c
+++ b/configuration.c
@@ -273,8 +273,8 @@ getnet(int c, unsigned char **p_r, unsigned char *plen_r, int *af_r,
     char *t;
     unsigned char *ip;
     unsigned char addr[16];
-    unsigned char plen;
-    int af, rc;
+    unsigned char plen = 0;
+    int af = 0, rc = 0;
 
     c = getword(c, &t, gnc, closure);
     if(c < -1)

--- a/configuration.h
+++ b/configuration.h
@@ -1,3 +1,5 @@
+#ifndef _BABEL_CONFIGURATION
+#define _BABEL_CONFIGURATION
 /*
 Copyright (c) 2007, 2008 by Juliusz Chroboczek
 
@@ -19,7 +21,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-
 /* Values returned by parse_config_from_string. */
 
 #define CONFIG_ACTION_DONE 0
@@ -77,3 +78,5 @@ int install_filter(const unsigned char *prefix, unsigned short plen,
                    const unsigned char *src_prefix, unsigned short src_plen,
                    struct filter_result *result);
 int finalise_config(void);
+
+#endif

--- a/disambiguation.c
+++ b/disambiguation.c
@@ -35,6 +35,7 @@ THE SOFTWARE.
 #include "source.h"
 #include "neighbour.h"
 #include "rule.h"
+#include "disambiguation.h"
 
 struct zone {
     const unsigned char *dst_prefix;

--- a/disambiguation.h
+++ b/disambiguation.h
@@ -1,3 +1,6 @@
+#ifndef _BABEL_DISAMBIGUATION
+#define _BABEL_DISAMBIGUATION
+
 /*
 Copyright (c) 2014 by Matthieu Boutier and Juliusz Chroboczek.
 
@@ -25,3 +28,5 @@ int kuninstall_route(const struct babel_route *route);
 int kswitch_routes(const struct babel_route *old, const struct babel_route *new);
 int kchange_route_metric(const struct babel_route *route,
                          unsigned refmetric, unsigned cost, unsigned add);
+
+#endif

--- a/disambiguation.h
+++ b/disambiguation.h
@@ -20,8 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-int kinstall_route(struct babel_route *route);
-int kuninstall_route(struct babel_route *route);
-int kswitch_routes(struct babel_route *old, struct babel_route *new);
-int kchange_route_metric(struct babel_route *route,
+int kinstall_route(const struct babel_route *route);
+int kuninstall_route(const struct babel_route *route);
+int kswitch_routes(const struct babel_route *old, const struct babel_route *new);
+int kchange_route_metric(const struct babel_route *route,
                          unsigned refmetric, unsigned cost, unsigned add);

--- a/generate-version.sh
+++ b/generate-version.sh
@@ -10,4 +10,6 @@ else
     version="unknown"
 fi
 
+echo "#ifndef BABELD_VERSION"
 echo "#define BABELD_VERSION \"$version\""
+echo "#endif"

--- a/interface.h
+++ b/interface.h
@@ -1,3 +1,6 @@
+#ifndef _BABEL_INTERFACE
+#define _BABEL_INTERFACE
+
 /*
 Copyright (c) 2007, 2008 by Juliusz Chroboczek
 
@@ -143,3 +146,4 @@ void set_timeout(struct timeval *timeout, int msecs);
 int interface_up(struct interface *ifp, int up);
 int interface_ll_address(struct interface *ifp, const unsigned char *address);
 void check_interfaces(void);
+#endif

--- a/kernel.h
+++ b/kernel.h
@@ -1,3 +1,6 @@
+#ifndef _BABEL_KERNEL
+#define _BABEL_KERNEL
+
 /*
 Copyright (c) 2007, 2008 by Juliusz Chroboczek
 
@@ -109,3 +112,4 @@ int add_rule(int prio, const unsigned char *src_prefix, int src_plen,
 int flush_rule(int prio, int family);
 int change_rule(int new_prio, int old_prio, const unsigned char *src, int plen,
                 int table);
+#endif

--- a/local.h
+++ b/local.h
@@ -1,3 +1,6 @@
+#ifndef _BABEL_LOCAL
+#define _BABEL_LOCAL
+
 /*
 Copyright (c) 2008 by Juliusz Chroboczek
 
@@ -55,3 +58,4 @@ int local_read(struct local_socket *s);
 int local_header(struct local_socket *s);
 struct local_socket *local_socket_create(int fd);
 void local_socket_destroy(int i);
+#endif

--- a/message.c
+++ b/message.c
@@ -54,8 +54,7 @@ unsigned char *unicast_buffer = NULL;
 struct neighbour *unicast_neighbour = NULL;
 struct timeval unicast_flush_timeout = {0, 0};
 
-static const unsigned char v4prefix[16] =
-    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 0, 0, 0, 0 };
+extern const unsigned char v4prefix[16];
 
 #define MAX_CHANNEL_HOPS 20
 

--- a/message.h
+++ b/message.h
@@ -1,3 +1,6 @@
+#ifndef _BABEL_MESSAGE
+#define _BABEL_MESSAGE
+
 /*
 Copyright (c) 2007, 2008 by Juliusz Chroboczek
 
@@ -109,3 +112,4 @@ void handle_request(struct neighbour *neigh, const unsigned char *prefix,
                     const unsigned char *src_prefix, unsigned char src_plen,
                     unsigned char hop_count,
                     unsigned short seqno, const unsigned char *id);
+#endif

--- a/neighbour.h
+++ b/neighbour.h
@@ -1,3 +1,6 @@
+#ifndef _BABEL_NEIGHBOUR
+#define _BABEL_NEIGHBOUR
+
 /*
 Copyright (c) 2007, 2008 by Juliusz Chroboczek
 
@@ -57,3 +60,5 @@ unsigned neighbour_rxcost(struct neighbour *neigh);
 unsigned neighbour_rttcost(struct neighbour *neigh);
 unsigned neighbour_cost(struct neighbour *neigh);
 int valid_rtt(struct neighbour *neigh);
+
+#endif

--- a/net.h
+++ b/net.h
@@ -1,3 +1,6 @@
+#ifndef _BABEL_NET
+#define _BABEL_NET
+
 /*
 Copyright (c) 2007, 2008 by Juliusz Chroboczek
 
@@ -27,3 +30,5 @@ int babel_send(int s,
                const struct sockaddr *sin, int slen);
 int tcp_server_socket(int port, int local);
 int unix_server_socket(const char *path);
+
+#endif

--- a/resend.h
+++ b/resend.h
@@ -1,3 +1,6 @@
+#ifndef _BABEL_RESEND
+#define _BABEL_RESEND
+
 /*
 Copyright (c) 2007, 2008 by Juliusz Chroboczek
 
@@ -19,7 +22,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-
 #define REQUEST_TIMEOUT 65000
 #define RESEND_MAX 3
 
@@ -66,3 +68,5 @@ int satisfy_request(const unsigned char *prefix, unsigned char plen,
 void expire_resend(void);
 void recompute_resend_time(void);
 void do_resend(void);
+
+#endif

--- a/route.c
+++ b/route.c
@@ -435,14 +435,14 @@ route_stream_done(struct route_stream *stream)
 int
 metric_to_kernel(int metric)
 {
-	if(metric >= INFINITY) {
-		return KERNEL_INFINITY;
-	} else if(reflect_kernel_metric) {
-		int r = kernel_metric + metric;
-		return r >= KERNEL_INFINITY ? KERNEL_INFINITY : r;
-	} else {
-		return kernel_metric;
-	}
+        if(metric >= INFINITY) {
+                return KERNEL_INFINITY;
+        } else if(reflect_kernel_metric) {
+                int r = kernel_metric + metric;
+                return r >= KERNEL_INFINITY ? KERNEL_INFINITY : r;
+        } else {
+                return kernel_metric;
+        }
 }
 
 /* This is used to maintain the invariant that the installed route is at

--- a/route.c
+++ b/route.c
@@ -212,7 +212,7 @@ resize_route_table(int new_slots)
 static struct babel_route *
 insert_route(struct babel_route *route)
 {
-    int i, n;
+    int i, n = 0;
 
     assert(!route->installed);
 

--- a/route.h
+++ b/route.h
@@ -1,3 +1,6 @@
+#ifndef _BABEL_ROUTE
+#define _BABEL_ROUTE
+
 /*
 Copyright (c) 2007-2011 by Juliusz Chroboczek
 
@@ -19,7 +22,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-
 #define DIVERSITY_NONE 0
 #define DIVERSITY_INTERFACE_1 1
 #define DIVERSITY_CHANNEL_1 2
@@ -125,3 +127,4 @@ void route_changed(struct babel_route *route,
                    struct source *oldsrc, unsigned short oldmetric);
 void route_lost(struct source *src, unsigned oldmetric);
 void expire_routes(void);
+#endif

--- a/rule.h
+++ b/rule.h
@@ -1,3 +1,6 @@
+#ifndef _BABEL_RULE
+#define _BABEL_RULE
+
 /*
 Copyright (c) 2015 by Matthieu Boutier and Juliusz Chroboczek.
 
@@ -19,7 +22,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-
 #define SRC_TABLE_NUM 10
 
 extern int src_table_idx; /* number of the first table */
@@ -31,3 +33,5 @@ int find_table(const unsigned char *dest, unsigned short plen,
                const unsigned char *src, unsigned short src_plen);
 void release_tables(void);
 int check_rules(void);
+
+#endif

--- a/source.h
+++ b/source.h
@@ -1,3 +1,6 @@
+#ifndef _BABEL_SOURCE
+#define _BABEL_SOURCE
+
 /*
 Copyright (c) 2007, 2008 by Juliusz Chroboczek
 
@@ -46,3 +49,5 @@ void update_source(struct source *src,
                    unsigned short seqno, unsigned short metric);
 void expire_sources(void);
 void check_sources_released(void);
+
+#endif

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+show_babel_packing

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,22 @@
+PREFIX = /usr/local
+MANDIR = $(PREFIX)/share/man
+
+PROGS = show_babel_packing
+
+CDEBUGFLAGS = -Os -g -Wall
+
+DEFINES = $(PLATFORM_DEFINES)
+
+CFLAGS = $(CDEBUGFLAGS) $(DEFINES) $(EXTRA_DEFINES)
+
+INCLUDES = babeld.h net.h kernel.c util.h interface.h source.h neighbour.h \
+       route.h xroute.h message.h resend.h configuration.h local.h \
+       disambiguation.h rule.h version.h
+
+INCLUDES1 := $(INCLUDES:%=../%)
+
+show_babel_packing: show_babel_packing.c $(INCLUDES1)
+	$(CC) $(CFLAGS) $(LDFLAGS) -I.. $@.c -o show_babel_packing $(OBJS) $(LDLIBS)
+
+clean:
+	-rm -f $(PROGS) show_babel_packing.o

--- a/tests/arch_detect.h
+++ b/tests/arch_detect.h
@@ -1,0 +1,53 @@
+/**
+ * arch_detect.h
+ *
+ * Toke Høiland-Jørgensen
+ * 2017-03-08
+ */
+
+#ifndef ARCH_DETECT_H
+#define ARCH_DETECT_H
+
+#ifdef __GNUC__
+#define GCC_VERSION (__GNUC__ * 10000 \
+                     + __GNUC_MINOR__ * 100 \
+                     + __GNUC_PATCHLEVEL__)
+#endif
+
+#define P(a)    typedef struct a a ##_t; \
+		printf("%4ld = sizeof (%s)\n", sizeof(a ## _t), #a)
+
+#if !(defined(__arm__) || defined(__aarch64__) || defined(__x86_64__) \
+	|| defined(__i386__) || defined(__mips__))
+	const char arch[] = "unknown";
+#else
+#if defined(__arm__) || defined(__aarch64__)
+#if defined(__ARM_ARCH_ISA_A64__) || defined(__aarch64__)
+	const char arch[] = "aarch64";
+#else
+#ifdef __ARM_ARCH_7S__
+	const char arch[] = "armv7s";
+#else
+#ifdef __ARM_ARCH_7A__
+	const char arch[] = "armv7";
+#endif
+#endif
+#endif /* end of arm detection. Fixme - need to find neon regs */
+#else
+#if defined(__x86_64__)
+	const char arch[] = "x86_64";
+#endif
+
+#if defined(__i386__)
+const char arch[] = "x86";
+#endif
+
+#if defined(__mips__)
+const char arch[] = "MIPS";
+#endif
+
+#endif
+
+#endif
+
+#endif

--- a/tests/show_babel_packing.c
+++ b/tests/show_babel_packing.c
@@ -1,0 +1,66 @@
+/**
+ * test_packing.c
+ */
+
+#include <unistd.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/time.h>
+#include <time.h>
+#include <signal.h>
+#include <assert.h>
+#include <string.h>
+#include <getopt.h>
+
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <net/if.h>
+#include <arpa/inet.h>
+
+#include "babeld.h"
+#include "util.h"
+#include "net.h"
+#include "kernel.h"
+#include "interface.h"
+#include "source.h"
+#include "neighbour.h"
+#include "route.h"
+#include "xroute.h"
+#include "message.h"
+#include "resend.h"
+#include "configuration.h"
+#include "local.h"
+#include "rule.h"
+#include "version.h"
+
+#include "arch_detect.h"
+
+int main()
+{
+#ifdef __GNUC__
+    printf("Compiled with gcc %d.%d.%d for the %s "
+        "architecture in %s mode\n",
+        __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__,
+        arch, __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__ ?
+        "little endian" : "big endian");
+#endif
+    P(filter_result);
+    P(filter);
+    P(buffered_update);
+    P(interface_conf);
+    P(interface);
+    P(kernel_route);
+    P(kernel_rule);
+    P(kernel_filter);
+    P(local_socket);
+    P(neighbour);
+    P(resend);
+    P(babel_route);
+    P(source);
+    P(xroute);
+    return 0;
+}

--- a/util.c
+++ b/util.c
@@ -246,7 +246,7 @@ normalize_prefix(unsigned char *restrict ret,
     return ret;
 }
 
-static const unsigned char v4prefix[16] =
+const unsigned char v4prefix[16] =
     {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xFF, 0xFF, 0, 0, 0, 0 };
 
 static const unsigned char llprefix[16] =

--- a/util.h
+++ b/util.h
@@ -1,3 +1,6 @@
+#ifndef _BABEL_UTIL
+#define _BABEL_UTIL
+
 /*
 Copyright (c) 2007, 2008 by Juliusz Chroboczek
 
@@ -156,3 +159,4 @@ static inline void kdebugf(const char *format, ...) { return; }
 
 #endif
 
+#endif

--- a/xroute.h
+++ b/xroute.h
@@ -1,3 +1,6 @@
+#ifndef _BABEL_XROUTE
+#define _BABEL_XROUTE
+
 /*
 Copyright (c) 2007, 2008 by Juliusz Chroboczek
 
@@ -45,3 +48,5 @@ void xroute_stream_done(struct xroute_stream *stream);
 int kernel_addresses(int ifindex, int ll,
                      struct kernel_route *routes, int maxroutes);
 int check_xroutes(int send_updates);
+
+#endif


### PR DESCRIPTION
This patch series consists of a bunch of miscellaneous improvements to the babeld build system,
improving the makefile to fully check dependencies, adding direct support for TAGS, tags and cscope, 
enabling whole program compilation, smashing some tabs that crept in elsewhere, fixing a missed dependency in disambiguation.h, enabling whole program compilation and assembly language output, and finally, adding a tests directory where a test for structure packing now exists as a further optimization aid.

It is the first of 5 major sets building on deeper improvements from the rabeld repository. 

Next up are patch sets for better error logging, then better error handling. 

After that - ghu willing - atomic updates, and some major performance improvements.
