### PR TITLE
Allow setting preferred source address in routes per interface via config file

### DIFF
--- a/babeld.man
+++ b/babeld.man
@@ -357,6 +357,10 @@ This specifies whether link quality estimation should be performed on this
 interface.  The default is to perform link quality estimation on wireless
 interfaces only.
 .TP
+.BR pref-src " {" ipv6-address }
+This specifies the preferred src address to be added to routes on this
+interface.
+.TP
 .BR split\-horizon " {" true | false | auto }
 This specifies whether to perform split-horizon processing on this
 interface.  The default is to perform split-horizon processing on

--- a/babeld.man
+++ b/babeld.man
@@ -34,9 +34,8 @@ Set the name of the file used for preserving long-term information
 between invocations of the
 .B babeld
 daemon.  If this file is deleted, the daemon will run in passive mode
-for 3 minutes when it is next started (see
-.B -P
-below), and other hosts might initially ignore it.  The default is
+for 3 minutes when it is next started, and other hosts might initially
+ignore it. The default is
 .BR /var/lib/babel-state .
 .TP
 .BI \-h " hello-interval"

--- a/configuration.c
+++ b/configuration.c
@@ -566,6 +566,14 @@ parse_anonymous_ifconf(int c, gnc_t gnc, void *closure,
             if(c < -1)
                 goto error;
             if_conf->lq = v;
+	} else if(strcmp(token, "pref-src") == 0) {
+            unsigned char *prefsrc = NULL;
+            c = getip(c, &prefsrc, NULL, gnc, closure);
+            if(c < -1)
+                goto error;
+            memcpy(if_conf->prefsrc, prefsrc, 16);
+	    if_conf->use_prefsrc = 1;
+            free(prefsrc);
         } else if(strcmp(token, "split-horizon") == 0) {
             int v;
             c = getbool(c, &v, gnc, closure);
@@ -702,6 +710,7 @@ merge_ifconf(struct interface_conf *dest,
     MERGE(update_interval);
     MERGE(cost);
     MERGE(type);
+    MERGE(use_prefsrc);
     MERGE(split_horizon);
     MERGE(lq);
     MERGE(faraway);

--- a/interface.h
+++ b/interface.h
@@ -41,16 +41,19 @@ struct interface_conf {
     unsigned hello_interval;
     unsigned update_interval;
     unsigned short cost;
-    char type;
-    char split_horizon;
-    char lq;
-    char faraway;
     int channel;
     int enable_timestamps;
     unsigned int rtt_decay;
     unsigned int rtt_min;
     unsigned int rtt_max;
     unsigned int max_rtt_penalty;
+    char type;
+    char split_horizon;
+    char lq;
+    char faraway;
+    char use_prefsrc;
+    char unicast;
+    unsigned char prefsrc[16];
     struct interface_conf *next;
 };
 
@@ -70,6 +73,8 @@ struct interface_conf {
 #define IF_FARAWAY (1 << 4)
 /* Send timestamps in Hello and IHU. */
 #define IF_TIMESTAMPS (1 << 5)
+/* use preferred source address on this interface */
+#define IF_PREFSRC (1 << 6)
 
 /* Only INTERFERING can appear on the wire. */
 #define IF_CHANNEL_UNKNOWN 0

--- a/kernel_netlink.c
+++ b/kernel_netlink.c
@@ -1050,6 +1050,17 @@ kernel_route(int operation, int table,
             rta->rta_type = RTA_SRC;
             memcpy(RTA_DATA(rta), src, sizeof(struct in6_addr));
         }
+
+        struct interface *ifp;
+
+        FOR_ALL_INTERFACES(ifp) {
+            if ( (ifp->ifindex == ifindex)  &&  (ifp->conf->use_prefsrc == 1 ) ) {
+                rta = RTA_NEXT(rta, len);
+                rta->rta_len = RTA_LENGTH(sizeof(struct in6_addr));
+                rta->rta_type = RTA_PREFSRC;
+                memcpy(RTA_DATA(rta), ifp->conf->prefsrc, sizeof(struct in6_addr));
+            }
+        }
     }
 
     rta = RTA_NEXT(rta, len);

--- a/message.c
+++ b/message.c
@@ -154,7 +154,7 @@ parse_update_subtlv(struct interface *ifp, int metric,
             return -1;
         }
         len = a[i + 1];
-        if(i + len > alen) {
+        if(i + len + 2 > alen) {
             fprintf(stderr, "Received truncated sub-TLV on Update.\n");
             return -1;
         }
@@ -196,7 +196,7 @@ parse_hello_subtlv(const unsigned char *a, int alen,
             return -1;
         }
         len = a[i + 1];
-        if(i + len > alen) {
+        if(i + len + 2 > alen) {
             fprintf(stderr, "Received truncated sub-TLV on Hello.\n");
             return -1;
         }
@@ -250,7 +250,7 @@ parse_ihu_subtlv(const unsigned char *a, int alen,
             return -1;
         }
         len = a[i + 1];
-        if(i + len > alen) {
+        if(i + len + 2 > alen) {
             fprintf(stderr, "Received truncated sub-TLV on IHU.\n");
             return -1;
         }
@@ -303,7 +303,7 @@ parse_other_subtlv(const unsigned char *a, int alen)
             return -1;
         }
         len = a[i + 1];
-        if(i + len > alen) {
+        if(i + len + 2 > alen) {
             fprintf(stderr, "Received truncated sub-TLV.\n");
             return -1;
         }
@@ -395,7 +395,7 @@ parse_packet(const unsigned char *from, struct interface *ifp,
             break;
         }
         len = message[1];
-        if(i + len > bodylen) {
+        if(i + len + 2 > bodylen) {
             fprintf(stderr, "Received truncated message.\n");
             break;
         }


### PR DESCRIPTION
this replaces #15 and is directed towards the unicast branch.

With this patch, we can set preferred source address stanzas in routes for each interface using a configuration like this:
interface babel-vpn-1374 type tunnel link-quality true update-interval 300 pref-src aaaa:bbbb:cccc:dddd:eeee::fffff
