### PR TITLE
Allow setting preferred source address in routes per interface via config file 

### DIFF
--- a/babeld.man
+++ b/babeld.man
@@ -357,6 +357,10 @@ This specifies whether link quality estimation should be performed on this
 interface.  The default is to perform link quality estimation on wireless
 interfaces only.
 .TP
+.BR pref-src " {" ipv6-address }
+This specifies the preferred src address to be added to routes on this
+interface.
+.TP
 .BR split\-horizon " {" true | false | auto }
 This specifies whether to perform split-horizon processing on this
 interface.  The default is to perform split-horizon processing on

--- a/configuration.c
+++ b/configuration.c
@@ -574,6 +574,13 @@ parse_anonymous_ifconf(int c, gnc_t gnc, void *closure,
             if(c < -1)
                 goto error;
             if_conf->lq = v;
+	} else if(strcmp(token, "pref-src") == 0) {
+            unsigned char *prefsrc = NULL;
+            c = getip(c, &prefsrc, NULL, gnc, closure);
+            if(c < -1)
+                goto error;
+            memcpy(if_conf->prefsrc, prefsrc, 16);
+            free(prefsrc);
         } else if(strcmp(token, "split-horizon") == 0) {
             int v;
             c = getbool(c, &v, gnc, closure);

--- a/interface.h
+++ b/interface.h
@@ -41,11 +41,6 @@ struct interface_conf {
     unsigned hello_interval;
     unsigned update_interval;
     unsigned short cost;
-    char type;
-    char split_horizon;
-    char lq;
-    char faraway;
-    char unicast;
     int channel;
     int enable_timestamps;
     int rfc6126;
@@ -53,6 +48,12 @@ struct interface_conf {
     unsigned int rtt_min;
     unsigned int rtt_max;
     unsigned int max_rtt_penalty;
+    char type;
+    char split_horizon;
+    char lq;
+    char faraway;
+    char unicast;
+    unsigned char prefsrc[16];
     struct interface_conf *next;
 };
 
@@ -72,6 +73,8 @@ struct interface_conf {
 #define IF_FARAWAY (1 << 4)
 /* Send most TLVs over unicast. */
 #define IF_UNICAST (1 << 5)
+/* use preferred source address on this interface */
+#define IF_PREFSRC (1 << 6)
 
 /* Only INTERFERING can appear on the wire. */
 #define IF_CHANNEL_UNKNOWN 0

--- a/kernel_netlink.c
+++ b/kernel_netlink.c
@@ -1071,6 +1071,17 @@ kernel_route(int operation, int table,
             rta->rta_type = RTA_SRC;
             memcpy(RTA_DATA(rta), src, sizeof(struct in6_addr));
         }
+
+        struct interface *ifp;
+
+        FOR_ALL_INTERFACES(ifp) {
+	    if ( (ifp->ifindex == ifindex)  &&  (ifp->conf) && (ifp->conf->prefsrc) ) {
+                rta = RTA_NEXT(rta, len);
+                rta->rta_len = RTA_LENGTH(sizeof(struct in6_addr));
+                rta->rta_type = RTA_PREFSRC;
+                memcpy(RTA_DATA(rta), ifp->conf->prefsrc, sizeof(struct in6_addr));
+            }
+        }
     }
 
     rta = RTA_NEXT(rta, len);


### PR DESCRIPTION
this replaces #15 and is directed towards the unicast branch.

With this patch, we can set preferred source address stanzas in routes for each interface using a configuration like this:
interface babel-vpn-1374 type tunnel link-quality true update-interval 300 pref-src aaaa:bbbb:cccc:dddd:eeee::fffff