### PR TITLE
kernel_netlink: Allow to run inside non-privileged docker container

### DIFF
--- a/kernel_netlink.c
+++ b/kernel_netlink.c
@@ -683,9 +683,9 @@ kernel_setup_interface(int setup, const char *ifname, int ifindex)
 		return -1;
 	}
     } else {
-        if(i >= 0 && old_if[i].rp_filter >= 0)
+        if(i >= 0 && old_if[i].rp_filter > 0)
             rc = write_proc(buf, old_if[i].rp_filter);
-        else
+        else if (i < 0)
             rc = -1;
 
         if(rc < 0)

--- a/kernel_netlink.c
+++ b/kernel_netlink.c
@@ -677,9 +677,11 @@ kernel_setup_interface(int setup, const char *ifname, int ifindex)
             fprintf(stderr,
                     "Warning: cannot save old configuration for %s.\n",
                     ifname);
-        rc = write_proc(buf, 0);
-        if(rc < 0)
-            return -1;
+	if(old_if[i].rp_filter) {
+	    rc = write_proc(buf, 0);
+	    if(rc < 0)
+		return -1;
+	}
     } else {
         if(i >= 0 && old_if[i].rp_filter >= 0)
             rc = write_proc(buf, old_if[i].rp_filter);


### PR DESCRIPTION
Only set rp_filter to 0 if it contains a different value when
initializing new interfaces. This is helpful to run babeld inside docker
without --privileged.