### PR TITLE
Rfc6126bis misc patches

### DIFF
--- a/babeld.c
+++ b/babeld.c
@@ -1122,7 +1122,7 @@ dump_tables(FILE *out)
 
     FOR_ALL_NEIGHBOURS(neigh) {
         fprintf(out, "Neighbour %s dev %s reach %04x ureach %04x "
-                "rxcost %d txcost %d rtt %s rttcost %d chan %d%s.\n",
+                "rxcost %u txcost %d rtt %s rttcost %u chan %d%s.\n",
                 format_address(neigh->address),
                 neigh->ifp->name,
                 neigh->hello.reach,

--- a/interface.c
+++ b/interface.c
@@ -295,7 +295,7 @@ interface_up(struct interface *ifp, int up)
 
         rc = kernel_setup_interface(1, ifp->name, ifp->ifindex);
         if(rc < 0) {
-            fprintf(stderr, "kernel_setup_interface(%s, %d) failed.\n",
+            fprintf(stderr, "kernel_setup_interface(%s, %u) failed.\n",
                     ifp->name, ifp->ifindex);
             goto fail;
         }
@@ -308,7 +308,7 @@ interface_up(struct interface *ifp, int up)
 
         mtu = kernel_interface_mtu(ifp->name, ifp->ifindex);
         if(mtu < 0) {
-            fprintf(stderr, "Warning: couldn't get MTU of interface %s (%d).\n",
+            fprintf(stderr, "Warning: couldn't get MTU of interface %s (%u).\n",
                     ifp->name, ifp->ifindex);
             mtu = 1280;
         }
@@ -318,7 +318,7 @@ interface_up(struct interface *ifp, int up)
         /* In IPv6, the minimum MTU is 1280, and every host must be able
            to reassemble up to 1500 bytes, but I'd rather not rely on this. */
         if(mtu < 128) {
-            fprintf(stderr, "Suspiciously low MTU %d on interface %s (%d).\n",
+            fprintf(stderr, "Suspiciously low MTU %d on interface %s (%u).\n",
                     mtu, ifp->name, ifp->ifindex);
             mtu = 128;
         }
@@ -338,7 +338,7 @@ interface_up(struct interface *ifp, int up)
         rc = resize_receive_buffer(mtu);
         if(rc < 0)
             fprintf(stderr, "Warning: couldn't resize "
-                    "receive buffer for interface %s (%d) (%d bytes).\n",
+                    "receive buffer for interface %s (%u) (%d bytes).\n",
                     ifp->name, ifp->ifindex, mtu);
 
         type = IF_CONF(ifp, type);
@@ -349,7 +349,7 @@ interface_up(struct interface *ifp, int up)
                 rc = kernel_interface_wireless(ifp->name, ifp->ifindex);
                 if(rc < 0) {
                     fprintf(stderr,
-                            "Warning: couldn't determine whether %s (%d) "
+                            "Warning: couldn't determine whether %s (%u) "
                             "is a wireless interface.\n",
                             ifp->name, ifp->ifindex);
                 } else if(rc) {
@@ -422,8 +422,8 @@ interface_up(struct interface *ifp, int up)
             IF_CONF(ifp, rtt_max) : 120000;
         if(ifp->rtt_max <= ifp->rtt_min) {
             fprintf(stderr,
-                    "Uh, rtt-max is less than or equal to rtt-min (%d <= %d). "
-                    "Setting it to %d.\n", ifp->rtt_max, ifp->rtt_min,
+                    "Uh, rtt-max is less than or equal to rtt-min (%u <= %u). "
+                    "Setting it to %u.\n", ifp->rtt_max, ifp->rtt_min,
                     ifp->rtt_min + 10000);
             ifp->rtt_max = ifp->rtt_min + 10000;
         }

--- a/kernel_netlink.c
+++ b/kernel_netlink.c
@@ -446,7 +446,7 @@ netlink_talk(struct nlmsghdr *nh)
     nh->nlmsg_seq = ++nl_command.seqno;
 
     kdebugf("Sending seqno %d from address %p (talk)\n",
-            nl_command.seqno, &nl_command.seqno);
+            nl_command.seqno, (void*)&nl_command.seqno);
 
     rc = sendmsg(nl_command.sock, &msg, 0);
     if(rc < 0 && (errno == EAGAIN || errno == EINTR)) {
@@ -514,7 +514,7 @@ netlink_send_dump(int type, void *data, int len) {
     buf.nh.nlmsg_len = NLMSG_LENGTH(len);
 
     kdebugf("Sending seqno %d from address %p (dump)\n",
-            nl_command.seqno, &nl_command.seqno);
+            nl_command.seqno, (void*)&nl_command.seqno);
 
     rc = sendmsg(nl_command.sock, &msg, 0);
     if(rc < buf.nh.nlmsg_len) {

--- a/kernel_netlink.c
+++ b/kernel_netlink.c
@@ -1590,7 +1590,7 @@ add_rule(int prio, const unsigned char *src_prefix, int src_plen, int table)
 
     message_header->nlmsg_len += current_attribute->rta_len;
     current_attribute = (void*)
-        ((char*)current_attribute) + current_attribute->rta_len;
+        ((char*)current_attribute + current_attribute->rta_len);
 
     /* src */
     current_attribute->rta_len = RTA_LENGTH(addr_size);
@@ -1599,7 +1599,7 @@ add_rule(int prio, const unsigned char *src_prefix, int src_plen, int table)
 
     message_header->nlmsg_len += current_attribute->rta_len;
     current_attribute = (void*)
-        ((char*)current_attribute) + current_attribute->rta_len;
+        ((char*)current_attribute + current_attribute->rta_len);
 
     /* send message */
     if(message_header->nlmsg_len > 64) {
@@ -1652,7 +1652,7 @@ flush_rule(int prio, int family)
 
     message_header->nlmsg_len += current_attribute->rta_len;
     current_attribute = (void*)
-        ((char*)current_attribute) + current_attribute->rta_len;
+        ((char*)current_attribute + current_attribute->rta_len);
 
     /* send message */
     if(message_header->nlmsg_len > 64) {

--- a/kernel_socket.c
+++ b/kernel_socket.c
@@ -588,7 +588,7 @@ print_kernel_route(int add, struct kernel_route *route)
         memcpy(ifname,"unk",4);
 
     fprintf(stderr,
-            "%s kernel route: dest: %s gw: %s metric: %d if: %s(%d) \n",
+            "%s kernel route: dest: %s gw: %s metric: %d if: %s(%u) \n",
             add == RTM_ADD ? "Add" :
             add == RTM_DELETE ? "Delete" : "Change",
             format_prefix(route->prefix, route->plen),

--- a/local.c
+++ b/local.c
@@ -145,7 +145,7 @@ local_notify_neighbour_1(struct local_socket *s,
 
     rttbuf[0] = '\0';
     if(valid_rtt(neigh)) {
-        rc = snprintf(rttbuf, 64, " rtt %s rttcost %d",
+        rc = snprintf(rttbuf, 64, " rtt %s rttcost %u",
                       format_thousands(neigh->rtt), neighbour_rttcost(neigh));
         if(rc < 0 || rc >= 64)
             rttbuf[0] = '\0';
@@ -154,7 +154,7 @@ local_notify_neighbour_1(struct local_socket *s,
     rc = snprintf(buf, 512,
                   "%s neighbour %lx address %s "
                   "if %s reach %04x ureach %04x "
-                  "rxcost %d txcost %d%s cost %d\n",
+                  "rxcost %u txcost %u%s cost %u\n",
                   local_kind(kind),
                   /* Neighbours never move around in memory , so we can use the
                      address as a unique identifier. */

--- a/neighbour.c
+++ b/neighbour.c
@@ -94,6 +94,7 @@ find_neighbour(const unsigned char *address, struct interface *ifp)
 
     neigh = calloc(1, sizeof(struct neighbour));
     if(neigh == NULL) {
+        free(buf);
         perror("malloc(neighbour)");
         return NULL;
     }

--- a/util.c
+++ b/util.c
@@ -302,7 +302,7 @@ format_thousands(unsigned int value)
     static char buf[4][15];
     static int i = 0;
     i = (i + 1) % 4;
-    snprintf(buf[i], 15, "%d.%.3d", value / 1000, value % 1000);
+    snprintf(buf[i], 15, "%u.%.3u", value / 1000, value % 1000);
     return buf[i];
 }
 

--- a/util.h
+++ b/util.h
@@ -88,7 +88,7 @@ unsigned char *normalize_prefix(unsigned char *restrict ret,
                                 const unsigned char *restrict prefix,
                                 unsigned char plen);
 const char *format_address(const unsigned char *address);
-const char *format_prefix(const unsigned char *address, unsigned char prefix);
+const char *format_prefix(const unsigned char *prefix, unsigned char plen);
 const char *format_eui64(const unsigned char *eui);
 const char *format_thousands(unsigned int value);
 int parse_address(const char *address, unsigned char *addr_r, int *af_r);
@@ -161,4 +161,3 @@ static inline void kdebugf(const char *format, ...) { return; }
 #endif
 
 #endif
-


### PR DESCRIPTION
Miscellaneous patches for warnings reported by [cppcheck](http://cppcheck.sourceforge.net/) and clang [scan-build](http://clang-analyzer.llvm.org/scan-build.html).

cppcheck also reports comparisons in the style of `rc < 0`, where `rc` is an unsigned int. Seems benign, but it may hide a real problem.