### PR TITLE
Add credits to contributors

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -1,0 +1,28 @@
+This file lists people who have contributed to babeld (in alphabetical order):
+
+    Antonin Décimo                <antonin dot decimo at gmail dot com>
+    Baptiste Jonglez              <baptiste dot jonglez at ens-lyon dot fr>
+    Christof Schulze              <christof dot schulze at gmx dot net>
+    Clara Do                      <clarado_perso at yahoo dot fr>
+    Dave Taht                     <dave at taht dot net>
+    Denis Ovsienko                <infrastation at yandex dot ru>
+    Dominyk Tiller                <dominyktiller at gmail dot com>
+    Etienne Marais                <etienne at marais dot green>
+    Fabian Bläse                  <fabian at blaese dot de>
+    Gabriel Kerneis               <gabriel at kerneis dot info>
+    Grégoire Henry                <gregoire dot henry at pps dot univ-paris-diderot dot fr>
+    Gwendoline Chouasne-Guillon   <yiyop at wanadoo dot fr>
+    Jernej Kos                    <jernej at kos dot mx>
+    Julien Cristau                <jcristau at debian dot org>
+    Julien Muchembled             <jm at jmuchemb dot eu>
+    Juliusz Chroboczek            <jch at irif dot fr>
+    Killian Lufau                 <killian dot lufau at nexedi dot com>
+    Léo Stefanesco                <leo dot lveb at gmail dot com>
+    Matthias Schiffer             <mschiffer at universe-factory dot net>
+    Matthieu Boutier              <boutier at irif dot fr>
+    Sawssen Hadded                <saw dot hadded at gmail dot com>
+    Stephane Glondu               <steph at glondu dot net>
+    Thomas Petazzoni              <thomas dot petazzoni at free-electrons dot com>
+    Toke Høiland-Jørgensen        <toke at toke dot dk>
+    Vincent Gross                 <dermiste at screwball-coders dot net>
+    Weronika Kołodziejak          <weronika dot kolodziejak at gmail dot com>


### PR DESCRIPTION
The credits (tcpdump-style) were obtained with a bit of magic.
In case an author used multiple mail addresses, only the most sensible one is kept.