### PR TITLE
New 'ignore_no_hmac' option

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -1227,6 +1227,8 @@ parse_config_line(int c, gnc_t gnc, void *closure,
         }
         add_key(key->id, key->type, key->len, key->value);
         free(key);
+    } else if(strcmp(token, "ignore_no_hmac") == 0) {
+        ignore_no_hmac = 1;
     } else {
         c = parse_option(c, gnc, closure, token);
         if(c < -1)

--- a/hmac.c
+++ b/hmac.c
@@ -39,6 +39,7 @@ THE SOFTWARE.
 
 struct key **keys = NULL;
 int numkeys = 0, maxkeys = 0;
+int ignore_no_hmac = 0;
 
 struct key *
 find_key(const char *id)
@@ -270,6 +271,7 @@ check_hmac(const unsigned char *packet, int packetlen, int bodylen,
 {
     int i = bodylen + 4;
     int len;
+    int rc = ignore_no_hmac ? 2 : 0;
 
     debugf("check_hmac %s -> %s\n",
 	   format_address(src), format_address(dst));
@@ -288,8 +290,9 @@ check_hmac(const unsigned char *packet, int packetlen, int bodylen,
 			    packet + i + 2 , len) == 1) {
 		return 1;
 	    }
+	    rc = 0;
 	}
 	i += len + 2;
     }
-    return 0;
+    return rc;
 }

--- a/hmac.h
+++ b/hmac.h
@@ -24,6 +24,8 @@ THE SOFTWARE.
 #define SHA1_BLOCK_SIZE 64
 #define RIPEMD160_BLOCK_SIZE 64
 
+extern int ignore_no_hmac;
+
 struct key *find_key(const char *id);
 struct key *retain_key(struct key *key);
 void release_key(struct key *key);

--- a/message.c
+++ b/message.c
@@ -587,15 +587,18 @@ parse_packet(const unsigned char *from, struct interface *ifp,
     }
 
     if(ifp->key != NULL) {
-	if(check_hmac(packet, packetlen, bodylen, neigh->address,
-		      to) != 1) {
-	    fprintf(stderr, "Received wrong hmac.\n");
-	    return;
-	}
-
-	if(preparse_packet(packet, bodylen, neigh, ifp) == 0) {
-	    fprintf(stderr, "Received wrong PC or failed the challenge.\n");
-	    return;
+	switch(check_hmac(packet, packetlen, bodylen, neigh->address, to)) {
+	    case 0:
+		fprintf(stderr, "Received wrong hmac.\n");
+		return;
+	    case 1:
+		if(preparse_packet(packet, bodylen, neigh, ifp) == 0) {
+		    fprintf(stderr, "Received wrong PC or failed the challenge.\n");
+		    return;
+		}
+		break;
+	    case 2: /* missing key ignored */
+		;
 	}
     }
 


### PR DESCRIPTION
There's already a way to change smoothly the HMAC key
of a babeld network:
1. restart babeld to accept a new key
2. once all babeld accept the new key,
   restart again to sign with the new key
3. once all babeld sign with the new key,
   restart again to stop accepting the old key

But there's currently no way to do a smooth upgrade when HMAC is not
used yet. With this new option, an interface accepts packets that:
- either lack a HMAC
- or have a valid HMAC