### PR TITLE
Fix version name generation when there are no tag

### DIFF
--- a/generate-version.sh
+++ b/generate-version.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -d .git ] ; then
+if [ -d .git ] && [ "$(git tag)" ] ; then
     version="$(git describe --dirty)"
 elif [ -f version ] ; then
     version="$(cat version)"


### PR DESCRIPTION
Set the version to be "unknown" when the git repository does not contain any tags. Currently, `generate_version.sh` crashes.