### PR TITLE
Fix dereference of a null pointer.

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -657,7 +657,7 @@ parse_anonymous_ifconf(int c, gnc_t gnc, void *closure,
     return c;
 
  error:
-    if(if_conf->ifname)
+    if(if_conf)
         free(if_conf->ifname);
     free(if_conf);
     return -2;


### PR DESCRIPTION
`if_conf` can be null if the allocation fails in line 520.