### PR TITLE
Reserve DTLS configuration flag.

### DIFF
--- a/interface.h
+++ b/interface.h
@@ -61,7 +61,7 @@ struct interface_conf {
 #define CONFIG_YES 2
 
 /* Interface is up. */
-# define IF_UP (1 << 0)
+#define IF_UP (1 << 0)
 /* Interface known to be wireless, unknown otherwise. */
 #define IF_WIRELESS (1<<1)
 /* Apply split horizon. */
@@ -76,6 +76,8 @@ struct interface_conf {
 #define IF_TIMESTAMPS (1 << 6)
 /* Remain compatible with RFC 6126. */
 #define IF_RFC6126 (1 << 7)
+/* Use Babel over DTLS on this interface. */
+#define IF_DTLS (1 << 9)
 
 /* Only INTERFERING can appear on the wire. */
 #define IF_CHANNEL_UNKNOWN 0


### PR DESCRIPTION
This is useful for a fork of babeld that implements Babel-over-DTLS. By reserving an integer for this flag, an implementer does not have to pick a high value for this flag to hope that it won’t collide with a future version of babeld. The collision happened twice with my dtls2 branch in 784c9f5, and with commit 494fbff. I picked `9` to be compatible with the future hmac branch; almost any other integer would be fine with me.