### PR TITLE
Remove src_plen assignments which break v4mapped encoding

### DIFF
--- a/message.c
+++ b/message.c
@@ -137,8 +137,6 @@ parse_update_subtlv(struct interface *ifp, int metric, int ae,
         }
     }
 
-    *src_plen = 0;
-
     while(i < alen) {
         type = a[i];
         if(type == SUBTLV_PAD1) {
@@ -170,8 +168,6 @@ parse_update_subtlv(struct interface *ifp, int metric, int ae,
                                 len - 1, src_prefix);
             if(rc < 0)
                 goto fail;
-            if(ae == 1)
-                (*src_plen) += 96;
         } else {
             debugf("Received unknown%s Update sub-TLV %d.\n",
                    (type & 0x80) != 0 ? " mandatory" : "", type);
@@ -305,8 +301,6 @@ parse_request_subtlv(int ae, const unsigned char *a, int alen,
 {
     int type, len, i = 0;
 
-    *src_plen = 0;
-
     while(i < alen) {
         type = a[0];
         if(type == SUBTLV_PAD1) {
@@ -336,8 +330,6 @@ parse_request_subtlv(int ae, const unsigned char *a, int alen,
                                 len - 1, src_prefix);
             if(rc < 0)
                 goto fail;
-            if(ae == 1)
-                (*src_plen) += 96;
         } else {
             debugf("Received unknown%s Route Request sub-TLV %d.\n",
                    ((type & 0x80) != 0) ? " mandatory" : "", type);


### PR DESCRIPTION
These assignments were introduced in f8bce04, probably
to ensure that src_plen doesn't contain any leftovers from
earlier revisions when source specific wasn't done via sub-TLVs.

This however breaks v4mapped encoding as a prefix length of 0
for IPv4 routes is represented as src_plen = 96. This offset is
already added outside of the affected functions and therefore
gets overwritten by this assignment.

Both functions contain an additional check if the message contains
ipv4 addresses, but as this check is only executed if the message has
a source-specific sub-TLV, the offset isn't added for non source-specific
routes.

Because the offset is already added outside of the subtlv parsing
functions, this additional check is also removed, as it would otherwise
break IPv4 source specifics by adding the IPv4 offset two times.

Signed-off-by: Fabian Bläse <fabian@blaese.de>