### PR TITLE
On Linux, restrict to CAP_NET_ADMIN and drop privileges.

### DIFF
--- a/babeld.c
+++ b/babeld.c
@@ -71,8 +71,8 @@ int random_id = 0;
 int do_daemonise = 0;
 int skip_kernel_setup = 0;
 const char *logfile = NULL,
-    *pidfile = "/var/run/babeld.pid",
-    *state_file = "/var/lib/babel-state";
+    *pidfile = "/var/run/babeld/babeld.pid",
+    *state_file = "/var/lib/babeld/babel-state";
 
 unsigned char *receive_buffer = NULL;
 int receive_buffer_size = 0;
@@ -362,7 +362,7 @@ main(int argc, char **argv)
 
     if(do_daemonise) {
         if(logfile == NULL)
-            logfile = "/var/log/babeld.log";
+            logfile = "/var/log/babeld/babeld.log";
     }
 
     rc = reopen_logfile();

--- a/babeld.man
+++ b/babeld.man
@@ -36,7 +36,7 @@ between invocations of the
 daemon.  If this file is deleted, the daemon will run in passive mode
 for 3 minutes when it is next started, and other hosts might initially
 ignore it. The default is
-.BR /var/lib/babel-state .
+.BR /var/lib/babeld/babel-state .
 .TP
 .BI \-h " hello-interval"
 Specify the interval in seconds at which scheduled hello packets are
@@ -144,13 +144,13 @@ Daemonise at startup.
 .BI \-L " logfile"
 Specify a file to log random ``how do you do?'' messages to.  This
 defaults to standard error if not daemonising, and to
-.B /var/log/babeld.log
+.B /var/log/babeld/babeld.log
 otherwise.
 .TP
 .BI \-I " pidfile"
 Specify a file to write our process id to, use no pidfile if set to the
 empty string.  The default is
-.BR /var/run/babeld.pid .
+.BR /var/run/babeld/babeld.pid .
 .TP
 .IR interface ...
 The list of interfaces on which the protocol should operate.
@@ -668,13 +668,13 @@ http://arxiv.org/pdf/1403.0445v4.pdf
 .B /etc/babeld.conf
 The default location of the configuration file.
 .TP
-.B /var/lib/babel\-state
+.B /var/lib/babeld/babel\-state
 The default location of the file storing long-term state.
 .TP
-.B /var/run/babeld.pid
+.B /var/run/babeld/babeld.pid
 The default location of the pid file.
 .TP
-.B /var/log/babeld.log
+.B /var/log/babeld/babeld.log
 The default location of the log file.
 .SH SIGNALS
 .TP

--- a/babeld.man
+++ b/babeld.man
@@ -152,6 +152,15 @@ Specify a file to write our process id to, use no pidfile if set to the
 empty string.  The default is
 .BR /var/run/babeld/babeld.pid .
 .TP
+.BI \-U " uid" \c
+.RI : gid
+Change the user ID to
+.IR uid ,
+an unprivileged user, and the group ID to
+.IR gid ,
+an unprivileged group; while using Linux capabilities to retain just
+required privileges.  Only supported on Linux.
+.TP
 .IR interface ...
 The list of interfaces on which the protocol should operate.
 .SH CONFIGURATION FILE FORMAT


### PR DESCRIPTION
This PR intends to let babeld be runnable under a dedicated user/group, with limited set of capabilities, at least of Linux. Priviledges are dropped as soon as possible in the design where babeld owns directories where it can write.
- `/var/log/babeld.log`, `/var/run/babeld.pid`, `/var/lib/babel-state` are moved (resp.) to `/var/log/babeld/babeld.log`, `/var/run/babeld/babeld.pid`, `/var/lib/babeld/babel-state`. The intent is that `/var/*/babeld/` directories are owned by the dedicated user/group. A system packager has to create the directories, it would be difficult for babeld to do so. The alternative would be to drop support for reopening the log and state file if babeld does not have the ownership.
- Option `-U uid:gid` is introduced, babeld will switch to the specified user/group and restrict its capabilities to `CAP_NET_ADMIN`. The code uses Linux specific headers and does not need to be linked with libcap or libcap-ng. It is inspired by BIRD.

Note that this could be accomplished without touching babeld code with a tight integration with systemd. :stuck_out_tongue: 

I don't know if there exists a similar mechanism for BSDs, so I've restricted the code to compile-time Linux.