### PR TITLE
New micro patches

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 .gitignore export-ignore
 .gitattributes export-ignore
+*.c diff=cpp
+*.h diff=cpp

--- a/babeld.c
+++ b/babeld.c
@@ -568,7 +568,7 @@ main(int argc, char **argv)
         if(!if_up(ifp))
             continue;
         /* Apply jitter before we send the first message. */
-        usleep(roughly(10000));
+        nap(roughly(10000));
         gettime(&now);
         send_hello(ifp);
         send_wildcard_retraction(ifp);
@@ -579,7 +579,7 @@ main(int argc, char **argv)
     FOR_ALL_INTERFACES(ifp) {
         if(!if_up(ifp))
             continue;
-        usleep(roughly(10000));
+        nap(roughly(10000));
         gettime(&now);
         send_hello(ifp);
         send_wildcard_retraction(ifp);
@@ -802,7 +802,7 @@ main(int argc, char **argv)
     }
 
     debugf("Exiting...\n");
-    usleep(roughly(10000));
+    nap(roughly(10000));
     gettime(&now);
 
     /* We need to flush so interface_updown won't try to reinstall. */
@@ -816,7 +816,7 @@ main(int argc, char **argv)
            association caches. */
         send_multicast_hello(ifp, 10, 1);
         flushbuf(&ifp->buf, ifp);
-        usleep(roughly(1000));
+        nap(roughly(1000));
         gettime(&now);
     }
     FOR_ALL_INTERFACES(ifp) {
@@ -826,7 +826,7 @@ main(int argc, char **argv)
         send_wildcard_retraction(ifp);
         send_multicast_hello(ifp, 1, 1);
         flushbuf(&ifp->buf, ifp);
-        usleep(roughly(10000));
+        nap(roughly(10000));
         gettime(&now);
         interface_updown(ifp, 0);
     }

--- a/babeld.man
+++ b/babeld.man
@@ -612,7 +612,8 @@ The following requests are currently defined:
 any configuration file directive, including
 .BR interface ;
 .IP \(bu
-.BR "flush interface" ;
+.B "flush interface"
+.IR "ifname" ;
 .IP \(bu
 .BR dump ;
 .IP \(bu

--- a/configuration.c
+++ b/configuration.c
@@ -668,7 +668,7 @@ static int
 parse_ifconf(int c, gnc_t gnc, void *closure,
              struct interface_conf **if_conf_return)
 {
-    char *token;
+    char *token = NULL;
     struct interface_conf *if_conf;
 
     if_conf = calloc(1, sizeof(struct interface_conf));

--- a/configuration.c
+++ b/configuration.c
@@ -794,6 +794,8 @@ flush_ifconf(struct interface_conf *if_conf)
         }
     }
     fprintf(stderr, "Warning: attempting to free nonexistent ifconf.\n");
+    free(if_conf->ifname);
+    free(if_conf);
 }
 
 static int

--- a/interface.c
+++ b/interface.c
@@ -107,6 +107,7 @@ flush_interface(char *ifname)
 
     local_notify_interface(ifp, LOCAL_FLUSH);
 
+    free(ifp->ipv4);
     free(ifp);
 
     return 1;

--- a/interface.c
+++ b/interface.c
@@ -47,24 +47,10 @@ THE SOFTWARE.
 
 struct interface *interfaces = NULL;
 
-static struct interface *
-last_interface(void)
-{
-    struct interface *ifp = interfaces;
-
-    if(!ifp)
-        return NULL;
-
-    while(ifp->next)
-        ifp = ifp->next;
-
-    return ifp;
-}
-
 struct interface *
 add_interface(char *ifname, struct interface_conf *if_conf)
 {
-    struct interface *ifp;
+    struct interface **last_interface = &interfaces, *ifp;
 
     FOR_ALL_INTERFACES(ifp) {
         if(strcmp(ifp->name, ifname) == 0) {
@@ -84,10 +70,9 @@ add_interface(char *ifname, struct interface_conf *if_conf)
     ifp->conf = if_conf ? if_conf : default_interface_conf;
     ifp->hello_seqno = (random() & 0xFFFF);
 
-    if(interfaces == NULL)
-        interfaces = ifp;
-    else
-        last_interface()->next = ifp;
+    while(*last_interface != NULL)
+        last_interface = &(*last_interface)->next;
+    *last_interface = ifp;
 
     local_notify_interface(ifp, LOCAL_ADD);
 

--- a/kernel_netlink.c
+++ b/kernel_netlink.c
@@ -351,7 +351,7 @@ netlink_read(struct netlink *nl, struct netlink *nl_ignore, int answer,
             goto socket_error;
         } else if(msg.msg_namelen != nl->socklen) {
             fprintf(stderr,
-                    "netlink_read: unexpected sender address length (%d)\n",
+                    "netlink_read: unexpected sender address length (%u)\n",
                     msg.msg_namelen);
             goto socket_error;
         } else if(nladdr.nl_pid != 0) {
@@ -364,7 +364,7 @@ netlink_read(struct netlink *nl, struct netlink *nl_ignore, int answer,
         for(nh = (struct nlmsghdr *)buf;
             NLMSG_OK(nh, len);
             nh = NLMSG_NEXT(nh, len)) {
-            kdebugf("%s{seq:%d}", (nh->nlmsg_flags & NLM_F_MULTI) ? "[multi] " : "",
+            kdebugf("%s{seq:%u}", (nh->nlmsg_flags & NLM_F_MULTI) ? "[multi] " : "",
                     nh->nlmsg_seq);
             if(!answer)
                 done = 1;
@@ -373,7 +373,7 @@ netlink_read(struct netlink *nl, struct netlink *nl_ignore, int answer,
                 continue;
             } else if(answer && (nh->nlmsg_pid != nl->sockaddr.nl_pid ||
                                  nh->nlmsg_seq != nl->seqno)) {
-                kdebugf("(wrong seqno %d %d /pid %d %d), ",
+                kdebugf("(wrong seqno %u %d /pid %u %u), ",
                         nh->nlmsg_seq, nl->seqno,
                         nh->nlmsg_pid, nl->sockaddr.nl_pid);
                 continue;
@@ -1028,7 +1028,7 @@ kernel_route(int operation, int table,
     use_src = (!is_default(src, src_plen) && kernel_disambiguate(ipv4));
 
     kdebugf("kernel_route: %s %s from %s "
-            "table %d metric %d dev %d nexthop %s\n",
+            "table %d metric %u dev %d nexthop %s\n",
             operation == ROUTE_ADD ? "add" :
             operation == ROUTE_FLUSH ? "flush" : "???",
             format_prefix(dest, plen), format_prefix(src, src_plen),
@@ -1441,7 +1441,7 @@ filter_addresses(struct nlmsghdr *nh, struct kernel_addr *addr)
         return 0;
     addr->ifindex = ifa->ifa_index;
 
-    kdebugf("found address on interface %s(%d): %s\n",
+    kdebugf("found address on interface %s(%u): %s\n",
             if_indextoname(ifa->ifa_index, ifname), ifa->ifa_index,
             format_address(addr->addr.s6_addr));
 

--- a/kernel_netlink.c
+++ b/kernel_netlink.c
@@ -396,7 +396,8 @@ netlink_read(struct netlink *nl, struct netlink *nl_ignore, int answer,
                 check_interfaces();
             } else if(skip) {
                 kdebugf("(skip)");
-            } if(filter) {
+            }
+            if(filter) {
                 kdebugf("(msg -> \"");
                 err = filter_netlink(nh, filter);
                 kdebugf("\" %d), ", err);

--- a/kernel_netlink.c
+++ b/kernel_netlink.c
@@ -1635,8 +1635,6 @@ add_rule(int prio, const unsigned char *src_prefix, int src_plen, int table)
     memcpy(RTA_DATA(current_attribute), src_prefix, addr_size);
 
     message_header->nlmsg_len += current_attribute->rta_len;
-    current_attribute = (void*)
-        ((char*)current_attribute + current_attribute->rta_len);
 
     /* send message */
     if(message_header->nlmsg_len > 64) {
@@ -1686,8 +1684,6 @@ flush_rule(int prio, int family)
     *(int*)RTA_DATA(current_attribute) = prio;
 
     message_header->nlmsg_len += current_attribute->rta_len;
-    current_attribute = (void*)
-        ((char*)current_attribute + current_attribute->rta_len);
 
     /* send message */
     if(message_header->nlmsg_len > 64) {

--- a/kernel_socket.c
+++ b/kernel_socket.c
@@ -49,8 +49,6 @@ THE SOFTWARE.
 #include "kernel.h"
 #include "util.h"
 
-
-
 static int get_sdl(struct sockaddr_dl *sdl, char *ifname);
 
 int export_table = -1, import_table_count = 0, import_tables[MAX_IMPORT_TABLES];
@@ -499,32 +497,35 @@ kernel_route(int operation, int table,
     msg.m_rtm.rtm_addrs = RTA_DST | RTA_GATEWAY;
     if(plen != 128) msg.m_rtm.rtm_addrs |= RTA_NETMASK;
 
-#define PUSHEUI(ifindex) \
-    do { char ifname[IFNAMSIZ]; \
-         struct sockaddr_dl *sdl = (struct sockaddr_dl*) data; \
-         if(!if_indextoname((ifindex), ifname))  \
-             return -1; \
-         if(get_sdl(sdl, ifname) < 0)   \
-             return -1; \
-         data = data + ROUNDUP(sdl->sdl_len); \
+#define PUSHEUI(ifindex)                                        \
+    do {                                                        \
+        char ifname[IFNAMSIZ];                                  \
+        struct sockaddr_dl *sdl = (struct sockaddr_dl*) data;   \
+        if(!if_indextoname((ifindex), ifname))                  \
+            return -1;                                          \
+        if(get_sdl(sdl, ifname) < 0)                            \
+            return -1;                                          \
+        data = data + ROUNDUP(sdl->sdl_len);                    \
     } while(0)
 
-#define PUSHADDR(src) \
-    do { struct sockaddr_in *sin = (struct sockaddr_in*) data; \
-         sin->sin_len = sizeof(struct sockaddr_in);  \
-         sin->sin_family = AF_INET; \
-         memcpy(&sin->sin_addr, (src) + 12, 4); \
-         data = data + ROUNDUP(sin->sin_len); \
+#define PUSHADDR(src)                                           \
+    do {                                                        \
+        struct sockaddr_in *sin = (struct sockaddr_in*) data;   \
+        sin->sin_len = sizeof(struct sockaddr_in);              \
+        sin->sin_family = AF_INET;                              \
+        memcpy(&sin->sin_addr, (src) + 12, 4);                  \
+        data = data + ROUNDUP(sin->sin_len);                    \
     } while(0)
 
-#define PUSHADDR6(src) \
-    do { struct sockaddr_in6 *sin6 = (struct sockaddr_in6*) data; \
-         sin6->sin6_len = sizeof(struct sockaddr_in6); \
-         sin6->sin6_family = AF_INET6; \
-         memcpy(&sin6->sin6_addr, (src), 16); \
-         if(IN6_IS_ADDR_LINKLOCAL (&sin6->sin6_addr)) \
-             SET_IN6_LINKLOCAL_IFINDEX (sin6->sin6_addr, ifindex); \
-         data = data + ROUNDUP(sin6->sin6_len); \
+#define PUSHADDR6(src)                                                  \
+    do {                                                                \
+        struct sockaddr_in6 *sin6 = (struct sockaddr_in6*) data;        \
+        sin6->sin6_len = sizeof(struct sockaddr_in6);                   \
+        sin6->sin6_family = AF_INET6;                                   \
+        memcpy(&sin6->sin6_addr, (src), 16);                            \
+        if(IN6_IS_ADDR_LINKLOCAL(&sin6->sin6_addr))                     \
+            SET_IN6_LINKLOCAL_IFINDEX (sin6->sin6_addr, ifindex);       \
+        data = data + ROUNDUP(sin6->sin6_len);                          \
     } while(0)
 
     /* KAME ipv6 stack does not support IPv4 mapped IPv6, so we have to
@@ -584,7 +585,7 @@ print_kernel_route(int add, struct kernel_route *route)
     char ifname[IFNAMSIZ];
 
     if(!if_indextoname(route->ifindex, ifname))
-        memcpy(ifname,"unk",4);
+        memcpy(ifname, "unk", 4);
 
     fprintf(stderr,
             "%s kernel route: dest: %s gw: %s metric: %d if: %s(%u) \n",
@@ -593,8 +594,7 @@ print_kernel_route(int add, struct kernel_route *route)
             format_prefix(route->prefix, route->plen),
             format_address(route->gw),
             route->metric,
-            ifname, route->ifindex
-            );
+            ifname, route->ifindex);
 }
 
 static int
@@ -778,7 +778,7 @@ socket_read(int sock, struct kernel_filter *filter)
             return 0;
         filter->route(&route, filter->route_closure);
         if(debug > 2)
-            print_kernel_route(1,&route);
+            print_kernel_route(1, &route);
         return 1;
 
     }
@@ -873,9 +873,3 @@ change_rule(int new_prio, int old_prio,
     errno = ENOSYS;
     return -1;
 }
-
-
-/* Local Variables:      */
-/* c-basic-offset: 4     */
-/* indent-tabs-mode: nil */
-/* End:                  */

--- a/local.c
+++ b/local.c
@@ -154,13 +154,13 @@ local_notify_neighbour_1(struct local_socket *s,
     }
 
     rc = snprintf(buf, 512,
-                  "%s neighbour %lx address %s "
+                  "%s neighbour %p address %s "
                   "if %s reach %04x ureach %04x "
                   "rxcost %u txcost %u%s cost %u\n",
                   local_kind(kind),
                   /* Neighbours never move around in memory , so we can use the
                      address as a unique identifier. */
-                  (unsigned long int)neigh,
+                  (void*)neigh,
                   format_address(neigh->address),
                   neigh->ifp->name,
                   neigh->hello.reach,
@@ -241,10 +241,10 @@ local_notify_route_1(struct local_socket *s, struct babel_route *route, int kind
                                            route->src->src_plen);
 
     rc = snprintf(buf, 512,
-                  "%s route %lx prefix %s from %s installed %s "
+                  "%s route %p prefix %s from %s installed %s "
                   "id %s metric %d refmetric %d via %s if %s\n",
                   local_kind(kind),
-                  (unsigned long)route,
+                  (void*)route,
                   dst_prefix, src_prefix,
                   route->installed ? "yes" : "no",
                   format_eui64(route->src->id),

--- a/message.c
+++ b/message.c
@@ -563,7 +563,7 @@ parse_packet(const unsigned char *from, struct interface *ifp,
             changed =
                 update_neighbour(neigh,
                                  unicast ? &neigh->uhello : &neigh->hello,
-                                 unicast, seqno, interval);
+                                 seqno, interval);
             update_neighbour_metric(neigh, changed);
             if(interval > 0)
                 /* Multiply by 3/2 to allow hellos to expire. */

--- a/message.c
+++ b/message.c
@@ -1104,7 +1104,7 @@ send_multicast_hello(struct interface *ifp, unsigned interval, int force)
     if(interval > 0)
         set_timeout(&ifp->hello_timeout, ifp->hello_interval);
 
-    debugf("Sending hello %d (%d) to %s.\n",
+    debugf("Sending hello %d (%u) to %s.\n",
            ifp->hello_seqno, interval, ifp->name);
 
     buffer_hello(&ifp->buf, ifp, ifp->hello_seqno, interval, 0);
@@ -1129,7 +1129,7 @@ send_unicast_hello(struct neighbour *neigh, unsigned interval, int force)
 
     neigh->hello_seqno = seqno_plus(neigh->hello_seqno, 1);
 
-    debugf("Sending unicast hello %d (%d) on %s.\n",
+    debugf("Sending unicast hello %d (%u) on %s.\n",
            neigh->hello_seqno, interval, neigh->ifp->name);
 
     buffer_hello(&neigh->buf, neigh->ifp, neigh->hello_seqno, interval, 1);
@@ -1358,7 +1358,7 @@ flushupdates(struct interface *ifp)
         if(!if_up(ifp))
             goto done;
 
-        debugf("  (flushing %d buffered updates on %s (%d))\n",
+        debugf("  (flushing %d buffered updates on %s (%u))\n",
                n, ifp->name, ifp->ifindex);
 
         /* In order to send fewer update messages, we want to send updates

--- a/neighbour.c
+++ b/neighbour.c
@@ -126,7 +126,7 @@ find_neighbour(const unsigned char *address, struct interface *ifp)
    This does not call local_notify_neighbour, see update_neighbour_metric. */
 int
 update_neighbour(const struct neighbour *neigh, struct hello_history *hist,
-                 int unicast, int hello, int hello_interval)
+                 int hello, int hello_interval)
 {
     int missed_hellos;
     int rc = 0;
@@ -230,8 +230,8 @@ check_neighbours()
     neigh = neighs;
     while(neigh) {
         int changed, rc;
-        changed = update_neighbour(neigh, &neigh->hello, 0, -1, 0);
-        rc = update_neighbour(neigh, &neigh->uhello, 1, -1, 0);
+        changed = update_neighbour(neigh, &neigh->hello, -1, 0);
+        rc = update_neighbour(neigh, &neigh->uhello, -1, 0);
         changed = changed || rc;
 
         if(neigh->hello.reach == 0 ||

--- a/neighbour.c
+++ b/neighbour.c
@@ -42,7 +42,8 @@ THE SOFTWARE.
 struct neighbour *neighs = NULL;
 
 static struct neighbour *
-find_neighbour_nocreate(const unsigned char *address, struct interface *ifp)
+find_neighbour_nocreate(const unsigned char *address,
+                        const struct interface *ifp)
 {
     struct neighbour *neigh;
     FOR_ALL_NEIGHBOURS(neigh) {
@@ -124,7 +125,7 @@ find_neighbour(const unsigned char *address, struct interface *ifp)
 /* Recompute a neighbour's rxcost.  Return true if anything changed.
    This does not call local_notify_neighbour, see update_neighbour_metric. */
 int
-update_neighbour(struct neighbour *neigh, struct hello_history *hist,
+update_neighbour(const struct neighbour *neigh, struct hello_history *hist,
                  int unicast, int hello, int hello_interval)
 {
     int missed_hellos;
@@ -213,7 +214,7 @@ reset_txcost(struct neighbour *neigh)
 }
 
 unsigned
-neighbour_txcost(struct neighbour *neigh)
+neighbour_txcost(const struct neighbour *neigh)
 {
     return neigh->txcost;
 }
@@ -274,7 +275,7 @@ two_three(int reach)
 }
 
 unsigned
-neighbour_rxcost(struct neighbour *neigh)
+neighbour_rxcost(const struct neighbour *neigh)
 {
     unsigned delay, udelay;
     unsigned short reach = neigh->hello.reach;
@@ -306,7 +307,7 @@ neighbour_rxcost(struct neighbour *neigh)
 }
 
 unsigned
-neighbour_rttcost(struct neighbour *neigh)
+neighbour_rttcost(const struct neighbour *neigh)
 {
     struct interface *ifp = neigh->ifp;
 
@@ -329,7 +330,7 @@ neighbour_rttcost(struct neighbour *neigh)
 }
 
 unsigned
-neighbour_cost(struct neighbour *neigh)
+neighbour_cost(const struct neighbour *neigh)
 {
     unsigned a, b, cost;
 
@@ -364,7 +365,7 @@ neighbour_cost(struct neighbour *neigh)
 }
 
 int
-valid_rtt(struct neighbour *neigh)
+valid_rtt(const struct neighbour *neigh)
 {
     return (timeval_minus_msec(&now, &neigh->rtt_time) < 180000) ? 1 : 0;
 }

--- a/neighbour.h
+++ b/neighbour.h
@@ -57,7 +57,7 @@ void flush_neighbour(struct neighbour *neigh);
 struct neighbour *find_neighbour(const unsigned char *address,
                                  struct interface *ifp);
 int update_neighbour(const struct neighbour *neigh, struct hello_history *hist,
-                     int unicast, int hello, int hello_interval);
+                     int hello, int hello_interval);
 unsigned check_neighbours(void);
 unsigned neighbour_txcost(const struct neighbour *neigh);
 unsigned neighbour_rxcost(const struct neighbour *neigh);

--- a/neighbour.h
+++ b/neighbour.h
@@ -56,11 +56,11 @@ extern struct neighbour *neighs;
 void flush_neighbour(struct neighbour *neigh);
 struct neighbour *find_neighbour(const unsigned char *address,
                                  struct interface *ifp);
-int update_neighbour(struct neighbour *neigh, struct hello_history *hist,
+int update_neighbour(const struct neighbour *neigh, struct hello_history *hist,
                      int unicast, int hello, int hello_interval);
 unsigned check_neighbours(void);
-unsigned neighbour_txcost(struct neighbour *neigh);
-unsigned neighbour_rxcost(struct neighbour *neigh);
-unsigned neighbour_rttcost(struct neighbour *neigh);
-unsigned neighbour_cost(struct neighbour *neigh);
-int valid_rtt(struct neighbour *neigh);
+unsigned neighbour_txcost(const struct neighbour *neigh);
+unsigned neighbour_rxcost(const struct neighbour *neigh);
+unsigned neighbour_rttcost(const struct neighbour *neigh);
+unsigned neighbour_cost(const struct neighbour *neigh);
+int valid_rtt(const struct neighbour *neigh);

--- a/neighbour.h
+++ b/neighbour.h
@@ -31,6 +31,7 @@ struct neighbour {
     struct neighbour *next;
     /* This is -1 when unknown, so don't make it unsigned */
     unsigned char address[16];
+    struct interface *ifp;
     struct hello_history hello;
     struct hello_history uhello; /* for Unicast Hellos */
     unsigned short txcost;
@@ -44,7 +45,6 @@ struct neighbour {
     struct timeval hello_rtt_receive_time;
     unsigned int rtt;
     struct timeval rtt_time;
-    struct interface *ifp;
     struct buffered buf;
 };
 

--- a/util.c
+++ b/util.c
@@ -39,6 +39,16 @@ THE SOFTWARE.
 #include "util.h"
 
 int
+nap(int usec)
+{
+    struct timespec ts = {
+        .tv_sec = 0,
+        .tv_nsec = usec * 1000
+    };
+    return nanosleep(&ts, NULL);
+}
+
+int
 roughly(int value)
 {
     if(value < 0)

--- a/util.h
+++ b/util.h
@@ -66,6 +66,7 @@ time_us(const struct timeval t)
     return (unsigned int) (t.tv_sec * 1000000 + t.tv_usec);
 }
 
+int nap(int usec);
 int roughly(int value);
 void timeval_minus(struct timeval *d,
                    const struct timeval *s1, const struct timeval *s2);


### PR DESCRIPTION
I added explanations to the commit messages when you requested it.
I’m not arguing for the commits you’ve strongly rejected.
 
> > Fix signed/unsigned comparison and printing warnings.
> > Use unsigned int for interface indexes.
> 
> Rejected. These are the kind of cosmetic changes that is likely to introduce subtle bugs.

Maybe the subtle bugs are already there.
Regarding the interface index, I’ve noticed that the kernel exposes them as `int` in rtnetlink and net_dev interfaces, but functions (e.g., `if_nametoindex`) in `net/if.h` use `unsigned int`. I conclude that this probably doesn’t matter and life is a lie.
I’ve restricted the commits to the safe subset of printing warnings.

> > Use %p to print pointers.
> 
> Rejected. As far as I recall `%p` prints data in an implementation-defined format.

You’re right, but does it really matter that it’s implementation-defined? There are currently two occurrences of `%p` in babeld.

> > gitattributes: ignore gitmodules, cpp mode for diff.
> 
> Rejected. There's no `.gitmodules` in this branch.

Right, pushing it to the MAC branch.

> As to the rest, please explain what actual problem it tries to solve.

It may create better patches.
 
> > generate_version: get git version and tag from anywhere.
> 
> I have no idea what this does. Please resubmit with a message explaining what particular problem you're trying to solve.

This would have been handy for my Makefile branch. It allows to detect if the current directory is a sub-directory of a git repo. This is useless now, I’m dropping the commit.

> > Don't memcpy channels if length is 0.
> 
> Applied. Did you check that this is the only occurrence of `memcpy(NULL, 0)`?

Yes.


Thanks.
