### PR TITLE
Disable neighbour acquisition

### DIFF
--- a/babeld.c
+++ b/babeld.c
@@ -70,6 +70,7 @@ int resend_delay = -1;
 int random_id = 0;
 int do_daemonise = 0;
 int skip_kernel_setup = 0;
+int neighbour_acquisition = 1;
 const char *logfile = NULL,
     *pidfile = "/var/run/babeld.pid",
     *state_file = "/var/lib/babel-state";

--- a/babeld.h
+++ b/babeld.h
@@ -92,6 +92,7 @@ extern const char *logfile, *pidfile, *state_file;
 extern int link_detect;
 extern int all_wireless;
 extern int has_ipv6_subtrees;
+extern int neighbour_acquisition;
 
 extern unsigned char myid[8];
 extern int have_id;

--- a/babeld.man
+++ b/babeld.man
@@ -317,6 +317,13 @@ source-specific routes.  The default is 10.
 .BI first-rule-priority " priority"
 This specifies smallest (highest) rule priority used with source-specific
 routes.  The default is 100.
+.TP
+.BR neighbour-acquisition " {" true | false }
+If this flag is set to
+.BR false ,
+no neighbour acquisition is done (e.g., via Multicast Hellos), and
+neighbours must be added via an external mechanism. The default is
+.BR true .
 .SS Interface configuration
 An interface is configured by a line with the following format:
 .IP

--- a/babeld.man
+++ b/babeld.man
@@ -324,6 +324,12 @@ If this flag is set to
 no neighbour acquisition is done (e.g., via Multicast Hellos), and
 neighbours must be added via an external mechanism. The default is
 .BR true .
+.TP
+.BI neighbour " address ifname"
+Add the neighbour with given
+.I address
+to the interface
+.IR ifname .
 .SS Interface configuration
 An interface is configured by a line with the following format:
 .IP
@@ -620,6 +626,9 @@ any configuration file directive, including
 .BR interface ;
 .IP \(bu
 .BR "flush interface" ;
+.IP \(bu
+.B "flush neighbour"
+.IR "address ifname" ;
 .IP \(bu
 .BR dump ;
 .IP \(bu

--- a/configuration.c
+++ b/configuration.c
@@ -850,7 +850,8 @@ parse_option(int c, gnc_t gnc, void *closure, char *token)
               strcmp(token, "daemonise") == 0 ||
               strcmp(token, "skip-kernel-setup") == 0 ||
               strcmp(token, "ipv6-subtrees") == 0 ||
-              strcmp(token, "reflect-kernel-metric") == 0) {
+              strcmp(token, "reflect-kernel-metric") == 0 ||
+              strcmp(token, "neighbour-acquisition") == 0) {
         int b;
         c = getbool(c, &b, gnc, closure);
         if(c < -1)
@@ -868,6 +869,8 @@ parse_option(int c, gnc_t gnc, void *closure, char *token)
             has_ipv6_subtrees = b;
         else if(strcmp(token, "reflect-kernel-metric") == 0)
             reflect_kernel_metric = b;
+        else if(strcmp(token, "neighbour-acquisition") == 0)
+            neighbour_acquisition = b;
         else
             abort();
     } else if(strcmp(token, "protocol-group") == 0) {

--- a/neighbour.c
+++ b/neighbour.c
@@ -41,7 +41,7 @@ THE SOFTWARE.
 
 struct neighbour *neighs = NULL;
 
-static struct neighbour *
+struct neighbour *
 find_neighbour_nocreate(const unsigned char *address, struct interface *ifp)
 {
     struct neighbour *neigh;

--- a/neighbour.c
+++ b/neighbour.c
@@ -72,6 +72,27 @@ flush_neighbour(struct neighbour *neigh)
     free(neigh);
 }
 
+int
+flush_neighbour2(const unsigned char *address, const struct interface *ifp)
+{
+    struct neighbour **neigh = &neighs, *flush;
+
+    while(*neigh != NULL &&
+          memcmp(address, (*neigh)->address, 16) != 0 &&
+          ifp != (*neigh)->ifp)
+        neigh = &(*neigh)->next;
+    flush = *neigh;
+    if(flush == NULL)
+        return -1;
+    *neigh = flush->next;
+    flush_neighbour_routes(flush);
+    flush_resends(flush);
+    local_notify_neighbour(flush, LOCAL_FLUSH);
+    free(flush->buf.buf);
+    free(flush);
+    return 0;
+}
+
 struct neighbour *
 find_neighbour(const unsigned char *address, struct interface *ifp)
 {

--- a/neighbour.h
+++ b/neighbour.h
@@ -54,6 +54,7 @@ extern struct neighbour *neighs;
     for(_neigh = neighs; _neigh; _neigh = _neigh->next)
 
 void flush_neighbour(struct neighbour *neigh);
+int flush_neighbour2(const unsigned char *address, const struct interface *ifp);
 struct neighbour *find_neighbour_nocreate(const unsigned char *address,
                                           struct interface *ifp);
 struct neighbour *find_neighbour(const unsigned char *address,

--- a/neighbour.h
+++ b/neighbour.h
@@ -54,6 +54,8 @@ extern struct neighbour *neighs;
     for(_neigh = neighs; _neigh; _neigh = _neigh->next)
 
 void flush_neighbour(struct neighbour *neigh);
+struct neighbour *find_neighbour_nocreate(const unsigned char *address,
+                                          struct interface *ifp);
 struct neighbour *find_neighbour(const unsigned char *address,
                                  struct interface *ifp);
 int update_neighbour(struct neighbour *neigh, struct hello_history *hist,


### PR DESCRIPTION
Hi!
This is a prototype for disabling neighbour acquisition in babeld, as suggested in https://github.com/jech/babeld/issues/58. I’m currently testing it ;-)
The first patch adds a global option, `neighbour-acquisition`, that is true by default, and when disabled will prevent babeld from sending multicast hellos (that may or may not be suitable, if that’s a bad idea, I’ll remove the feature) and prevents babeld from ever creating neighbours.
The second patch adds a way to add and flush neighbours from the configuration interface.