### PR TITLE
Skip kernel_setup_interface when `skip-kernel-setup` is enabled.

### DIFF
--- a/kernel_netlink.c
+++ b/kernel_netlink.c
@@ -680,6 +680,8 @@ get_old_if(const char *ifname)
 int
 kernel_setup_interface(int setup, const char *ifname, int ifindex)
 {
+    if(skip_kernel_setup) return 1;
+
     char buf[100];
     int i, rc;
 


### PR DESCRIPTION
Setting sysctls is not allowed for unprivileged users, so let's not try
to set per interface rp_filter when `skip-kernel-setup` is set.

After this change babeld can run as an unprivileged users with
CAP_NET_ADMIN. The user needs to take care of setting up the sysctls
themselves.

Fixes: #67