### PR TITLE
local: make local_kind function accessible

### DIFF
--- a/local.c
+++ b/local.c
@@ -80,7 +80,7 @@ write_timeout(int fd, const void *buf, int len)
     }
 }
 
-static const char *
+const char *
 local_kind(int kind)
 {
     switch(kind) {

--- a/local.h
+++ b/local.h
@@ -55,3 +55,4 @@ int local_read(struct local_socket *s);
 int local_header(struct local_socket *s);
 struct local_socket *local_socket_create(int fd);
 void local_socket_destroy(int i);
+const char *local_kind(int kind);


### PR DESCRIPTION
The kind-definitions are conatined in the header file:
- LOCAL_FLUSH 0
- LOCAL_ADD 1
- LOCAL_CHANGE 2

The function (local_kind) that converts them into strings again is private. New addons (for example openwrt ubus bindings) that make use of babeld should also use the same function to convert the kind to string format. This allows to ensure uniformity over all addons.