### PR TITLE
Put functions from configuration.c into header

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -47,7 +47,7 @@ static struct filter *output_filters = NULL;
 static struct filter *redistribute_filters = NULL;
 static struct filter *install_filters = NULL;
 struct interface_conf *default_interface_conf = NULL;
-static struct interface_conf *interface_confs = NULL;
+struct interface_conf *interface_confs = NULL;
 
 /* This indicates whether initial configuration is done.  See
    finalize_config below. */
@@ -904,7 +904,7 @@ merge_ifconf(struct interface_conf *dest,
 #undef MERGE
 }
 
-static void
+void
 add_ifconf(struct interface_conf *if_conf, struct interface_conf **if_confs)
 {
     if(*if_confs == NULL) {

--- a/configuration.c
+++ b/configuration.c
@@ -869,7 +869,7 @@ add_filter(struct filter *filter, struct filter **filters)
     }
 }
 
-static void
+void
 merge_ifconf(struct interface_conf *dest,
              const struct interface_conf *src1,
              const struct interface_conf *src2)

--- a/configuration.h
+++ b/configuration.h
@@ -63,6 +63,9 @@ extern struct interface_conf *interface_confs;
 
 void add_ifconf(struct interface_conf *if_conf, struct interface_conf **if_confs);
 void flush_ifconf(struct interface_conf *if_conf);
+void merge_ifconf(struct interface_conf *dest,
+                  const struct interface_conf *src1,
+                  const struct interface_conf *src2);
 
 int parse_config_from_file(const char *filename, int *line_return);
 int parse_config_from_string(char *string, int n, const char **message_return);

--- a/configuration.h
+++ b/configuration.h
@@ -59,7 +59,9 @@ struct filter {
 };
 
 extern struct interface_conf *default_interface_conf;
+extern struct interface_conf *interface_confs;
 
+void add_ifconf(struct interface_conf *if_conf, struct interface_conf **if_confs);
 void flush_ifconf(struct interface_conf *if_conf);
 
 int parse_config_from_file(const char *filename, int *line_return);


### PR DESCRIPTION
Commit 1:
    Put add_ifcon to configuration.h
    
    You want to use default_interface_conf as a basis to write an interface config. To do so, you write an empty interface config and use merge_ifconf to merge the default settings into your interface config. This commit puts merge_ifconf into the header.

Commit 2:

    Put add_ifcon to configuration.h
    
    If you want to add an interface with a different config you need to call
    add_interface with an interface_conf as an argument. add_interface is
    already located in the configuration.h. However, add_ifconf is not
    available. The commit puts add_ifcon into the header. Further, it also
    adds interface_confs to the header. The add_ifconf requires as a
    parameter the interface_confs list.
