### PR TITLE
Publish add filter function

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -42,10 +42,10 @@ THE SOFTWARE.
 #include "hmac.h"
 #include "configuration.h"
 
-static struct filter *input_filters = NULL;
-static struct filter *output_filters = NULL;
-static struct filter *redistribute_filters = NULL;
-static struct filter *install_filters = NULL;
+struct filter *input_filters = NULL;
+struct filter *output_filters = NULL;
+struct filter *redistribute_filters = NULL;
+struct filter *install_filters = NULL;
 struct interface_conf *default_interface_conf = NULL;
 static struct interface_conf *interface_confs = NULL;
 
@@ -853,7 +853,7 @@ parse_key(int c, gnc_t gnc, void *closure, struct key **key_return)
     return -2;
 }
 
-static void
+void
 add_filter(struct filter *filter, struct filter **filters)
 {
     if(*filters == NULL) {

--- a/configuration.h
+++ b/configuration.h
@@ -58,6 +58,10 @@ struct filter {
     struct filter *next;
 };
 
+extern struct filter *input_filters;
+extern struct filter *output_filters;
+extern struct filter *redistribute_filters;
+extern struct filter *install_filters;
 extern struct interface_conf *default_interface_conf;
 
 void flush_ifconf(struct interface_conf *if_conf);
@@ -66,6 +70,7 @@ int parse_config_from_file(const char *filename, int *line_return);
 int parse_config_from_string(char *string, int n, const char **message_return);
 void renumber_filters(void);
 
+void add_filter(struct filter *filter, struct filter **filters);
 int input_filter(const unsigned char *id,
                  const unsigned char *prefix, unsigned short plen,
                  const unsigned char *src_prefix, unsigned short src_plen,


### PR DESCRIPTION
Make add_filter public. If you want to add a filter you need to call add_filter with the corresponding filter list as an argument.
This can be:
- input_filters
- output_filters
- redistribute_filters
- install_filters

This commit puts the add_filter and the filter lists into the header so filters can be added outside the configuration.c file.