### PR TITLE
Allow using blake2/sha2 system libaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ local.o: local.c version.h
 
 kernel.o: kernel_netlink.c kernel_socket.c
 
+# NetBSD make doesn't use -o by default
+.c.o:
+	$(CC) $(CFLAGS) -o $@ -c $<
+
 version.h:
 	./generate-version.sh > version.h
 

--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,22 @@ CDEBUGFLAGS = -Os -g -Wall
 
 DEFINES = $(PLATFORM_DEFINES)
 
-CFLAGS = $(CDEBUGFLAGS) $(DEFINES) $(EXTRA_DEFINES)
+SHA2_SRCS ?= rfc6234/sha224-256.c
+SHA2_CFLAGS ?= -I.
 
-LDLIBS = -lrt
+BLAKE_SRCS ?= BLAKE2/ref/blake2s-ref.c
+BLAKE_CFLAGS ?= -IBLAKE2/ref
+
+LDLIBS ?= -lrt
+
+CFLAGS = $(CDEBUGFLAGS) $(DEFINES) $(EXTRA_DEFINES) \
+         $(SHA2_CFLAGS) $(BLAKE_CFLAGS)
 
 SRCS = babeld.c net.c kernel.c util.c interface.c source.c neighbour.c \
        route.c xroute.c message.c resend.c configuration.c local.c \
-       hmac.c rfc6234/sha224-256.c BLAKE2/ref/blake2s-ref.c
+       hmac.c $(SHA2_SRCS) $(BLAKE_SRCS)
 
-OBJS = babeld.o net.o kernel.o util.o interface.o source.o neighbour.o \
-       route.o xroute.o message.o resend.o configuration.o local.o \
-       hmac.o rfc6234/sha224-256.o BLAKE2/ref/blake2s-ref.o
+OBJS = $(SRCS:.c=.o)
 
 babeld: $(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o babeld $(OBJS) $(LDLIBS)

--- a/hmac.c
+++ b/hmac.c
@@ -27,8 +27,8 @@ THE SOFTWARE.
 #include <sys/time.h>
 #include <netinet/in.h>
 
-#include "rfc6234/sha.h"
-#include "BLAKE2/ref/blake2.h"
+#include <rfc6234/sha.h>
+#include <blake2.h>
 
 #include "babeld.h"
 #include "interface.h"


### PR DESCRIPTION
Using ?= to assign LDLIBS allows overriding it from the environment to add
(for exmaple) -lb2 on Debian.

Instead of hardcoding the path to blake2.h we use -I in CFLAGS instead and
introduce a variable NO_BUNDLED_LIBS which can be set via the environment
again.

Finally since keeping SRCS and OBJS in sync is tedious maximus I replace
OBJS with a simple patsubst call.