### PR TITLE
man: Make "Filtering rules" section more prominent

### DIFF
--- a/babeld.man
+++ b/babeld.man
@@ -433,7 +433,6 @@ Enable HMAC security on this interface, and use the key
 .BR accept\-bad\-signatures " {" true | false }
 Accept packets with no signature or an incorrect signature.  This only has
 an effect if a key was configured on an interface.  The default is false.
-.TP
 .SS Filtering rules
 A filtering rule is defined by a single line with the following format:
 .IP


### PR DESCRIPTION
The .TP made the heading indented quite deeply whereas I think it should be at the same level as the "Interface configuration" section.

Before:

```
   Interface configuration
       An interface is configured by a line with the following format:

              interface name [parameter...]
[...]
       accept-bad-signatures {true|false}
              Accept  packets  with  no  signature  or an incorrect signature.
              This only has an effect if a key was configured on an interface.
              The default is false.

          Filtering rules
              A  filtering rule is defined by a single line with the following
              format:

              filter selector...  action
```

After:

```
       accept-bad-signatures {true|false}
              Accept  packets  with  no  signature  or an incorrect signature.
              This only has an effect if a key was configured on an interface.
              The default is false.

   Filtering rules
       A filtering rule is defined by a single line with the following format:

              filter selector...  action

```