### PR TITLE
Fix allow-duplicates config option not taking effect

### DIFF
--- a/configuration.c
+++ b/configuration.c
@@ -989,7 +989,7 @@ parse_option(int c, gnc_t gnc, void *closure, char *token)
             protocol_port = v;
         else if(strcmp(token, "kernel-priority") == 0)
             kernel_metric = v;
-        else if(strcmp(token, "allow_duplicates") == 0)
+        else if(strcmp(token, "allow-duplicates") == 0)
             allow_duplicates = v;
         else if(strcmp(token, "local-port") == 0) {
             local_server_port = v;


### PR DESCRIPTION
The config parser first matches for "allow-duplicates" (with dash) then again for "allow_duplicates" (with underscore) which can never match.

```
    if(strcmp(token, "protocol-port") == 0 ||
       strcmp(token, "kernel-priority") == 0 ||
       strcmp(token, "allow-duplicates") == 0 ||
       [...]
       strcmp(token, "kernel-check-interval") == 0) {
        int v;
        c = getint(c, &v, gnc, closure);
        if(c < -1 || v <= 0 || v >= 0xFFFF)
            goto error;
        [...]
        else if(strcmp(token, "allow_duplicates") == 0)
            allow_duplicates = v;
```