### PR TITLE
Added id to input filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tags
 *.orig
 *~
 \#*#
+.vscode/

--- a/configuration.c
+++ b/configuration.c
@@ -1503,13 +1503,14 @@ redistribute_filter(const unsigned char *prefix, unsigned short plen,
 }
 
 int
-install_filter(const unsigned char *prefix, unsigned short plen,
+install_filter(const unsigned char *id,
+               const unsigned char *prefix, unsigned short plen,
                const unsigned char *src_prefix, unsigned short src_plen,
                unsigned int ifindex,
                struct filter_result *result)
 {
     int res;
-    res = do_filter(install_filters, NULL, prefix, plen,
+    res = do_filter(install_filters, id, prefix, plen,
                     src_prefix, src_plen, NULL, ifindex, 0, result);
     if(res < 0)
         res = INFINITY;

--- a/configuration.h
+++ b/configuration.h
@@ -84,7 +84,8 @@ int redistribute_filter(const unsigned char *prefix, unsigned short plen,
                     const unsigned char *src_prefix, unsigned short src_plen,
                     unsigned int ifindex, int proto,
                     struct filter_result *result);
-int install_filter(const unsigned char *prefix, unsigned short plen,
+int install_filter(const unsigned char *id,
+                   const unsigned char *prefix, unsigned short plen,
                    const unsigned char *src_prefix, unsigned short src_plen,
                    unsigned int ifindex, struct filter_result *result);
 int finalise_config(void);

--- a/kernel.h
+++ b/kernel.h
@@ -85,7 +85,8 @@ int kernel_route(int operation, int table,
                  const unsigned char *pref_src,
                  const unsigned char *gate, int ifindex, unsigned int metric,
                  const unsigned char *newgate, int newifindex,
-                 unsigned int newmetric, int newtable);
+                 unsigned int newmetric, int newtable,
+                 const unsigned char *newpref_src);
 int kernel_dump(int operation, struct kernel_filter *filter);
 int kernel_callback(struct kernel_filter *filter);
 int if_eui64(char *ifname, int ifindex, unsigned char *eui);

--- a/kernel_netlink.c
+++ b/kernel_netlink.c
@@ -959,7 +959,8 @@ kernel_route(int operation, int table,
              const unsigned char *pref_src,
              const unsigned char *gate, int ifindex, unsigned int metric,
              const unsigned char *newgate, int newifindex,
-             unsigned int newmetric, int newtable)
+             unsigned int newmetric, int newtable,
+             const unsigned char *newpref_src)
 {
     union { char raw[1024]; struct nlmsghdr nh; } buf;
     struct rtmsg *rtm;
@@ -1011,11 +1012,11 @@ kernel_route(int operation, int table,
         kernel_route(ROUTE_FLUSH, table, dest, plen,
                      src, src_plen, pref_src,
                      gate, ifindex, metric,
-                     NULL, 0, 0, 0);
+                     NULL, 0, 0, 0, NULL);
         rc = kernel_route(ROUTE_ADD, newtable, dest, plen,
-                          src, src_plen, pref_src,
+                          src, src_plen, newpref_src,
                           newgate, newifindex, newmetric,
-                          NULL, 0, 0, 0);
+                          NULL, 0, 0, 0, NULL);
         if(rc < 0) {
             if(errno == EEXIST)
                 rc = 1;

--- a/kernel_socket.c
+++ b/kernel_socket.c
@@ -407,7 +407,8 @@ kernel_route(int operation, int table,
              const unsigned char *pref_src,
              const unsigned char *gate, int ifindex, unsigned int metric,
              const unsigned char *newgate, int newifindex,
-             unsigned int newmetric, int newtable)
+             unsigned int newmetric, int newtable,
+             const unsigned char *newpref_src)
 {
     struct {
         struct rt_msghdr m_rtm;
@@ -423,7 +424,7 @@ kernel_route(int operation, int table,
 
     /* Source-specific routes & preferred source IPs
      * are not implemented yet for BSD. */
-    if((!is_default(src, src_plen)) || pref_src) {
+    if((!is_default(src, src_plen)) || pref_src || newpref_src) {
         errno = ENOSYS;
         return -1;
     }
@@ -454,11 +455,11 @@ kernel_route(int operation, int table,
         kernel_route(ROUTE_FLUSH, table, dest, plen,
                      src, src_plen, NULL,
                      gate, ifindex, metric,
-                     NULL, 0, 0, 0);
+                     NULL, 0, 0, 0, NULL);
         return kernel_route(ROUTE_ADD, table, dest, plen,
                             src, src_plen, NULL,
                             newgate, newifindex, newmetric,
-                            NULL, 0, 0, 0);
+                            NULL, 0, 0, 0, NULL);
 
     }
 

--- a/route.c
+++ b/route.c
@@ -446,7 +446,8 @@ change_route(int operation, const struct babel_route *route, int metric,
     unsigned int ifindex = route->neigh->ifp->ifindex;
     int m, table;
 
-    m = install_filter(route->src->prefix, route->src->plen,
+    m = install_filter(route->src->id,
+                       route->src->prefix, route->src->plen,
                        route->src->src_prefix, route->src->src_plen,
                        ifindex, &filter_result);
     if(m >= INFINITY && operation == ROUTE_ADD) {


### PR DESCRIPTION
This allows to have pref-src set by router id, for example to have source routing for IPv4

```
# ISP1
install ip 0.0.0.0/0 eq 0 id 0e:6a:a3:ff:fe:a7:00:00 pref-src 66.199.5.162
# ISP2
install ip 0.0.0.0/0 eq 0 id 0e:08:1c:ff:fe:dd:00:00 pref-src 12.144.66.186
```