### PR TITLE
Remove unused route_interferes.

### DIFF
--- a/route.h
+++ b/route.h
@@ -65,7 +65,6 @@ void route_stream_done(struct route_stream *stream);
 void install_route(struct babel_route *route);
 void uninstall_route(struct babel_route *route);
 int route_feasible(struct babel_route *route);
-int route_interferes(struct babel_route *route, struct interface *ifp);
 int update_feasible(struct source *src,
                     unsigned short seqno, unsigned short refmetric);
 void change_smoothing_half_life(int half_life);


### PR DESCRIPTION
The implementation of this function and any reference to it were deleted in the past, but the declaration in `route.h` still remains.