### PR TITLE
Fix compilation error on linux

### DIFF
--- a/net.c
+++ b/net.c
@@ -37,6 +37,10 @@ THE SOFTWARE.
 #include <arpa/inet.h>
 #include <errno.h>
 
+#if defined(__UCLIBC__)
+#include <linux/in6.h>
+#endif
+
 #include "babeld.h"
 #include "util.h"
 #include "net.h"


### PR DESCRIPTION
This patch fixes the following compilation error raised by the bump to version 1.13.1 in Buildroot:

net.c: In function 'babel_send':
net.c:199:27: error: 'IPV6_DONTFRAG' undeclared (first use in this function)
  199 |         cmsg->cmsg_type = IPV6_DONTFRAG;;